### PR TITLE
fix: rate-limit known-device probe and TOTP QR

### DIFF
--- a/src/config/limits.ts
+++ b/src/config/limits.ts
@@ -35,6 +35,9 @@
     // /api/sync read request budget per minute.
     // /api/sync 读请求每分钟配额。
     syncReadRequestsPerMinute: 1000,
+    // Public known-device probe request budget per minute (per client identifier).
+    // 公开 known-device 探测接口每分钟请求配额（按客户端标识）。
+    knownDeviceProbeRequestsPerMinute: 10,
     // Fixed window size for API rate limiting in seconds.
     // API 限流固定窗口大小（秒）。
     apiWindowSeconds: 60,


### PR DESCRIPTION
前端生成二维码：src/setup/pageTemplate.ts  
在浏览器端用 qrcode-generator 直接把 otpauth://... 生成二维码，不再走API；并保留本地占位图兜底（脚本异常时）。
为 GET /api/devices/knowndevice 添加了限流 每ip每分钟10次 避免被枚举