### PR TITLE
fix: add [build] command to wrangler.toml for CI/CD compatibility

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,9 @@ main = "src/index.ts"
 compatibility_date = "2024-01-01"
 assets = { directory = "./dist", not_found_handling = "single-page-application", run_worker_first = ["/api/*", "/identity/*", "/icons/*", "/setup/*", "/config", "/notifications/*", "/.well-known/*"] }
 
+[build]
+command = "npm run build"
+
 # D1 Database for storing vault data
 [[d1_databases]]
 binding = "DB"


### PR DESCRIPTION
## Problem

Since commit `15e0a29` (2026-03-01), the `assets.directory` in `wrangler.toml` was changed from `./public` to `./dist`.

Previously, `./public` was a git-tracked static directory — it existed immediately after `git clone`, so `npx wrangler deploy` worked without any prior build step.

Now, `./dist` is generated by `vite build` and is listed in `.gitignore`. When Cloudflare Workers Builds (Git integration CI/CD) runs the default deploy command `npx wrangler deploy`, the `dist/` directory does not exist, causing the deployment to fail:

```
✘ [ERROR] The directory specified by the "assets.directory" field in your
  configuration file does not exist:
  /opt/buildhome/repo/dist
```

## Workaround

Users can manually change the deploy command in Cloudflare Dashboard:

**Workers → Settings → Builds → Deploy command** → `npm run build && npx wrangler deploy`

## Fix

Add a `[build]` section to `wrangler.toml`:

```toml
[build]
command = "npm run build"
```

This tells Wrangler to automatically run `npm run build` (which executes `vite build`) before deploying. It works consistently across:

- **Cloudflare Workers Builds (Git integration)** — the CI environment will run the build command before deploy
- **Local `npx wrangler deploy`** — Wrangler will run the build command first
- **`npm run deploy`** — still works as before (build runs twice harmlessly, or can be simplified to just `wrangler deploy`)