### PR TITLE
使用Github Actions将 NodeWarden 自动部署到 Cloudflare Worker（自行验证过）

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -28,6 +28,7 @@ permissions:
 # 全局环境变量：
 # =============================================
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   # Cloudflare API 令牌（必填）
   # 创建地址：https://dash.cloudflare.com/profile/api-tokens
   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || vars.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
# Cloudflare Workers 部署指南

## 触发条件

| 触发方式      | 说明                                       |
|---------------|--------------------------------------------|
| **自动触发**  | 推送代码到 `main` 分支时                   |
| **手动触发**  | GitHub Actions → `workflow_dispatch` → 可选存储类型(R2/KV) |

## 配置 Action Secret 或 Variables
 
### Github Secrets（必须）

| 变量名                  | 说明                                 |       备注               |
|-------------------------|----------------------------------------|--------------------------|
| `CLOUDFLARE_API_TOKEN`  |Cloudflare API 令牌 |   [创建链接](https://dash.cloudflare.com/profile/api-tokens)    |
| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare API 账户 ID  |            |
| `JWT_SECRET`            | 用于用户认证的 JWT 密钥(最低 32 位随机字符)  |       |

### Github Variables（可选的）

| 变量名        | 默认值 | 说明                 |
|---------------|--------|----------------------|
| `STORAGE_TYPE` | `R2`   | 附件存储类型，可选 `R2` 或 `KV` |



在仓库 **Settings → Variables and Secrets** 中配置：

**Secrets（私密变量）：**
- `CLOUDFLARE_API_TOKEN` - Cloudflare API 令牌
- `CLOUDFLARE_ACCOUNT_ID` - Cloudflare 账户 ID
- `JWT_SECRET` - JWT 密钥（最低 32 位随机字符）

**Variables（公开变量）：**
- `STORAGE_TYPE` - 存储类型，填写 `R2` 或 `KV`（可选，默认 `R2`）
