### PR TITLE
feat(vault): add folder rename button and dialog in sidebar

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1116,6 +1116,7 @@ export default function App() {
     onBulkMoveVaultItems: vaultSendActions.bulkMoveVaultItems,
     onVerifyMasterPassword: vaultSendActions.verifyMasterPassword,
     onCreateFolder: vaultSendActions.createFolder,
+    onRenameFolder: vaultSendActions.renameFolder,
     onDeleteFolder: vaultSendActions.deleteFolder,
     onBulkDeleteFolders: vaultSendActions.bulkDeleteFolders,
     onDownloadVaultAttachment: vaultSendActions.downloadVaultAttachment,

--- a/webapp/src/components/AppMainRoutes.tsx
+++ b/webapp/src/components/AppMainRoutes.tsx
@@ -74,6 +74,7 @@ export interface AppMainRoutesProps {
   onBulkMoveVaultItems: (ids: string[], folderId: string | null) => Promise<void>;
   onVerifyMasterPassword: (email: string, password: string) => Promise<void>;
   onCreateFolder: (name: string) => Promise<void>;
+  onRenameFolder: (folderId: string, name: string) => Promise<void>;
   onDeleteFolder: (folderId: string) => Promise<void>;
   onBulkDeleteFolders: (folderIds: string[]) => Promise<void>;
   onDownloadVaultAttachment: (cipher: Cipher, attachmentId: string) => Promise<void>;
@@ -192,6 +193,7 @@ export default function AppMainRoutes(props: AppMainRoutesProps) {
             onVerifyMasterPassword={props.onVerifyMasterPassword}
             onNotify={props.onNotify}
             onCreateFolder={props.onCreateFolder}
+            onRenameFolder={props.onRenameFolder}
             onDeleteFolder={props.onDeleteFolder}
             onBulkDeleteFolders={props.onBulkDeleteFolders}
             onDownloadAttachment={props.onDownloadVaultAttachment}

--- a/webapp/src/components/VaultPage.tsx
+++ b/webapp/src/components/VaultPage.tsx
@@ -50,6 +50,7 @@ interface VaultPageProps {
   onVerifyMasterPassword: (email: string, password: string) => Promise<void>;
   onNotify: (type: 'success' | 'error' | 'warning', text: string) => void;
   onCreateFolder: (name: string) => Promise<void>;
+  onRenameFolder: (folderId: string, name: string) => Promise<void>;
   onDeleteFolder: (folderId: string) => Promise<void>;
   onBulkDeleteFolders: (folderIds: string[]) => Promise<void>;
   onDownloadAttachment: (cipher: Cipher, attachmentId: string) => Promise<void>;
@@ -91,6 +92,8 @@ export default function VaultPage(props: VaultPageProps) {
   const [moveFolderId, setMoveFolderId] = useState('__none__');
   const [createFolderOpen, setCreateFolderOpen] = useState(false);
   const [newFolderName, setNewFolderName] = useState('');
+  const [pendingRenameFolder, setPendingRenameFolder] = useState<Folder | null>(null);
+  const [renameFolderName, setRenameFolderName] = useState('');
   const [pendingDeleteFolder, setPendingDeleteFolder] = useState<Folder | null>(null);
   const [deleteAllFoldersOpen, setDeleteAllFoldersOpen] = useState(false);
   const [totpLive, setTotpLive] = useState<{ code: string; remain: number } | null>(null);
@@ -699,6 +702,22 @@ function folderName(id: string | null | undefined): string {
     }
   }
 
+  async function confirmRenameFolder(): Promise<void> {
+    if (!pendingRenameFolder) return;
+    if (!renameFolderName.trim()) {
+      props.onNotify('error', t('txt_folder_name_is_required'));
+      return;
+    }
+    setBusy(true);
+    try {
+      await props.onRenameFolder(pendingRenameFolder.id, renameFolderName);
+      setPendingRenameFolder(null);
+      setRenameFolderName('');
+    } finally {
+      setBusy(false);
+    }
+  }
+
   async function confirmBulkRestore(): Promise<void> {
     const ids = Object.entries(selectedMap)
       .filter(([, selected]) => selected)
@@ -806,6 +825,10 @@ function folderName(id: string | null | undefined): string {
           onChangeFilter={setSidebarFilter}
           onOpenDeleteAllFolders={() => setDeleteAllFoldersOpen(true)}
           onOpenCreateFolder={() => setCreateFolderOpen(true)}
+          onOpenRenameFolder={(folder) => {
+            setPendingRenameFolder(folder);
+            setRenameFolderName(folder.decName || folder.name || '');
+          }}
           onOpenDeleteFolder={setPendingDeleteFolder}
         />
 
@@ -986,6 +1009,8 @@ function folderName(id: string | null | undefined): string {
         folders={props.folders}
         createFolderOpen={createFolderOpen}
         newFolderName={newFolderName}
+        renameFolderOpen={!!pendingRenameFolder}
+        renameFolderName={renameFolderName}
         pendingDeleteFolder={pendingDeleteFolder}
         deleteAllFoldersOpen={deleteAllFoldersOpen}
         repromptOpen={repromptOpen}
@@ -1036,6 +1061,12 @@ function folderName(id: string | null | undefined): string {
           setNewFolderName('');
         }}
         onNewFolderNameChange={setNewFolderName}
+        onConfirmRenameFolder={() => void confirmRenameFolder()}
+        onCancelRenameFolder={() => {
+          setPendingRenameFolder(null);
+          setRenameFolderName('');
+        }}
+        onRenameFolderNameChange={setRenameFolderName}
         onConfirmDeleteFolder={() => void confirmDeleteFolder()}
         onCancelDeleteFolder={() => setPendingDeleteFolder(null)}
         onConfirmDeleteAllFolders={() => void confirmDeleteAllFolders()}
@@ -1050,8 +1081,4 @@ function folderName(id: string | null | undefined): string {
     </>
   );
 }
-
-
-
-
 

--- a/webapp/src/components/vault/VaultDialogs.tsx
+++ b/webapp/src/components/vault/VaultDialogs.tsx
@@ -19,6 +19,8 @@ interface VaultDialogsProps {
   folders: Folder[];
   createFolderOpen: boolean;
   newFolderName: string;
+  renameFolderOpen: boolean;
+  renameFolderName: string;
   pendingDeleteFolder: Folder | null;
   deleteAllFoldersOpen: boolean;
   repromptOpen: boolean;
@@ -42,6 +44,9 @@ interface VaultDialogsProps {
   onConfirmCreateFolder: () => void;
   onCancelCreateFolder: () => void;
   onNewFolderNameChange: (value: string) => void;
+  onConfirmRenameFolder: () => void;
+  onCancelRenameFolder: () => void;
+  onRenameFolderNameChange: (value: string) => void;
   onConfirmDeleteFolder: () => void;
   onCancelDeleteFolder: () => void;
   onConfirmDeleteAllFolders: () => void;
@@ -147,6 +152,13 @@ export default function VaultDialogs(props: VaultDialogsProps) {
         <label className="field">
           <span>{t('txt_folder_name')}</span>
           <input className="input" value={props.newFolderName} onInput={(e) => props.onNewFolderNameChange((e.currentTarget as HTMLInputElement).value)} />
+        </label>
+      </ConfirmDialog>
+
+      <ConfirmDialog open={props.renameFolderOpen} title={t('txt_rename_folder')} message={t('txt_enter_a_folder_name')} confirmText={t('txt_save')} cancelText={t('txt_cancel')} onConfirm={props.onConfirmRenameFolder} onCancel={props.onCancelRenameFolder}>
+        <label className="field">
+          <span>{t('txt_folder_name')}</span>
+          <input className="input" value={props.renameFolderName} onInput={(e) => props.onRenameFolderNameChange((e.currentTarget as HTMLInputElement).value)} />
         </label>
       </ConfirmDialog>
 

--- a/webapp/src/components/vault/VaultSidebar.tsx
+++ b/webapp/src/components/vault/VaultSidebar.tsx
@@ -8,6 +8,7 @@ import {
   Globe,
   KeyRound,
   LayoutGrid,
+  Pencil,
   ShieldUser,
   Star,
   StickyNote,
@@ -28,6 +29,7 @@ interface VaultSidebarProps {
   onChangeFilter: (filter: SidebarFilter) => void;
   onOpenDeleteAllFolders: () => void;
   onOpenCreateFolder: () => void;
+  onOpenRenameFolder: (folder: Folder) => void;
   onOpenDeleteFolder: (folder: Folder) => void;
 }
 
@@ -112,6 +114,20 @@ export default function VaultSidebar(props: VaultSidebarProps) {
               <span className="tree-label" title={folder.decName || folder.name || folder.id}>
                 {folder.decName || folder.name || folder.id}
               </span>
+            </button>
+            <button
+              type="button"
+              className="folder-delete-btn"
+              title={t('txt_edit')}
+              aria-label={t('txt_edit')}
+              disabled={props.busy}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                props.onOpenRenameFolder(folder);
+              }}
+            >
+              <Pencil size={12} />
             </button>
             <button
               type="button"

--- a/webapp/src/hooks/useVaultSendActions.ts
+++ b/webapp/src/hooks/useVaultSendActions.ts
@@ -42,6 +42,7 @@ import {
   importCiphers,
   type CiphersImportPayload,
   type ImportedCipherMapEntry,
+  updateFolder,
   updateCipher,
   unarchiveCipher,
   uploadCipherAttachment,
@@ -336,6 +337,28 @@ export default function useVaultSendActions(options: UseVaultSendActionsOptions)
           onNotify('success', t('txt_folder_deleted'));
         } catch (error) {
           onNotify('error', error instanceof Error ? error.message : t('txt_delete_folder_failed'));
+          throw error;
+        }
+      },
+
+      async renameFolder(folderId: string, name: string) {
+        const id = String(folderId || '').trim();
+        const folderName = String(name || '').trim();
+        if (!id) {
+          onNotify('error', t('txt_folder_not_found'));
+          return;
+        }
+        if (!folderName) {
+          onNotify('error', t('txt_folder_name_is_required'));
+          return;
+        }
+        try {
+          if (!session) throw new Error(t('txt_vault_key_unavailable'));
+          await updateFolder(authedFetch, session, id, folderName);
+          await Promise.all([refetchCiphers(), refetchFolders()]);
+          onNotify('success', t('txt_folder_renamed'));
+        } catch (error) {
+          onNotify('error', error instanceof Error ? error.message : t('txt_rename_folder_failed'));
           throw error;
         }
       },

--- a/webapp/src/lib/i18n.ts
+++ b/webapp/src/lib/i18n.ts
@@ -439,8 +439,11 @@ const messages: Record<Locale, Record<string, string>> = {
     txt_first_name: "First Name",
     txt_folder: "Folder",
     txt_folder_created: "Folder created",
+    txt_folder_renamed: "Folder renamed",
     txt_folder_name: "Folder Name",
     txt_folder_name_is_required: "Folder name is required",
+    txt_rename_folder: "Rename Folder",
+    txt_rename_folder_failed: "Rename folder failed",
     txt_folders: "Folders",
     txt_hidden: "Hidden",
     txt_hide: "Hide",
@@ -1281,7 +1284,10 @@ const zhCNOverrides: Record<string, string> = {
   txt_firefox_browser: 'Firefox 浏览器',
   txt_firefox_extension: 'Firefox 扩展',
   txt_folder_created: '文件夹已创建',
+  txt_folder_renamed: '文件夹已重命名',
   txt_folder_name_is_required: '文件夹名称不能为空',
+  txt_rename_folder: '重命名文件夹',
+  txt_rename_folder_failed: '重命名文件夹失败',
   txt_ie_browser: 'IE 浏览器',
   txt_invite_code_optional: '邀请码（首位注册者无需填写，其他人必填）',
   txt_invite_created: '邀请码已创建',
@@ -1629,4 +1635,3 @@ export function setLocale(next: Locale): void {
     // ignore storage errors
   }
 }
-


### PR DESCRIPTION
### Motivation
- Provide a quick way to rename folders directly from the vault sidebar with the same compact action style as the delete button.

### Description
- Added a rename action button (pencil icon) to each folder row in `webapp/src/components/vault/VaultSidebar.tsx` that prevents event bubbling and opens the rename dialog.  
- Introduced a rename-folder dialog in `webapp/src/components/vault/VaultDialogs.tsx` with a single name input and Save/Cancel controls mirroring the create-folder dialog.  
- Wired rename state and flow into `webapp/src/components/VaultPage.tsx` using `pendingRenameFolder` / `renameFolderName` and the `confirmRenameFolder` handler to validate input and call the rename callback.  
- Added `renameFolder` action in `webapp/src/hooks/useVaultSendActions.ts` which calls the existing `updateFolder` API, refreshes data, and emits success/error notifications, and threaded the `onRenameFolder` prop through `App`, `AppMainRoutes`, and `VaultPage`.  
- Added i18n strings (`txt_rename_folder`, `txt_rename_folder_failed`, `txt_folder_renamed`) in `webapp/src/lib/i18n.ts` and reused existing button CSS (`.folder-delete-btn`) for consistent styling.

### Testing
- Ran `npm run build` and the production build completed successfully without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69caa073d44083208ecddc154e070310)