### PR TITLE
feat: first-factor Passkey login/unlock and account Passkey management

### DIFF
--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -168,6 +168,38 @@ CREATE TABLE IF NOT EXISTS trusted_two_factor_device_tokens (
 CREATE INDEX IF NOT EXISTS idx_trusted_two_factor_device_tokens_user_device
   ON trusted_two_factor_device_tokens(user_id, device_identifier);
 
+CREATE TABLE IF NOT EXISTS passkeys (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  credential_id TEXT NOT NULL UNIQUE,
+  public_key_spki TEXT NOT NULL,
+  algorithm INTEGER NOT NULL,
+  counter INTEGER NOT NULL DEFAULT 0,
+  transports TEXT,
+  name TEXT NOT NULL,
+  rp_id TEXT NOT NULL,
+  vault_enc_key TEXT NOT NULL,
+  vault_mac_key TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  last_used_at TEXT,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_passkeys_user_updated ON passkeys(user_id, updated_at);
+CREATE INDEX IF NOT EXISTS idx_passkeys_credential ON passkeys(credential_id);
+
+CREATE TABLE IF NOT EXISTS passkey_challenges (
+  id TEXT PRIMARY KEY,
+  challenge TEXT NOT NULL,
+  action TEXT NOT NULL,
+  user_id TEXT,
+  expires_at INTEGER NOT NULL,
+  created_at TEXT NOT NULL,
+  origin TEXT,
+  rp_id TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_passkey_challenges_expires ON passkey_challenges(expires_at);
+
 -- Rate limiting
 CREATE TABLE IF NOT EXISTS login_attempts_ip (
   ip TEXT PRIMARY KEY,

--- a/src/handlers/accounts.ts
+++ b/src/handlers/accounts.ts
@@ -7,6 +7,7 @@ import { generateUUID } from '../utils/uuid';
 import { LIMITS } from '../config/limits';
 import { isTotpEnabled, verifyTotpToken } from '../utils/totp';
 import { createRecoveryCode, recoveryCodeEquals } from '../utils/recovery-code';
+import { base64UrlToBytes, bytesToBase64Url, parseClientData, readAuthenticatorCounter, verifyAssertionSignature } from '../utils/passkey';
 import { buildAccountKeys } from '../utils/user-decryption';
 
 function looksLikeEncString(value: string): boolean {
@@ -113,6 +114,27 @@ function toProfile(user: User, env: Env): ProfileResponse {
     status: user.status,
     object: 'profile',
   };
+}
+
+interface PasskeyAssertionRequest {
+  id?: string;
+  rawId?: string;
+  response?: {
+    clientDataJSON?: string;
+    authenticatorData?: string;
+    signature?: string;
+  };
+  type?: string;
+}
+
+function getPasskeyOriginAndRpId(request: Request): { origin: string; rpId: string } {
+  const url = new URL(request.url);
+  return { origin: url.origin, rpId: url.hostname };
+}
+
+function randomPasskeyChallenge(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  return bytesToBase64Url(bytes);
 }
 
 // POST /api/accounts/register
@@ -709,6 +731,176 @@ export async function handleRecoverTwoFactor(request: Request, env: Env): Promis
     newRecoveryCode: user.totpRecoveryCode,
     object: 'twoFactorRecovery',
   });
+}
+
+// GET /api/accounts/passkeys
+export async function handleListPasskeys(request: Request, env: Env, userId: string): Promise<Response> {
+  void request;
+  const storage = new StorageService(env.DB);
+  const rows = await storage.listPasskeysByUserId(userId);
+  return jsonResponse({
+    object: 'list',
+    data: rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      lastUsedAt: row.lastUsedAt,
+      transports: row.transports ? row.transports.split(',').filter(Boolean) : [],
+      object: 'passkey',
+    })),
+  });
+}
+
+// POST /api/accounts/passkeys/register/options
+export async function handlePasskeyRegisterOptions(request: Request, env: Env, userId: string): Promise<Response> {
+  const storage = new StorageService(env.DB);
+  const user = await storage.getUserById(userId);
+  if (!user) return errorResponse('User not found', 404);
+  const { origin, rpId } = getPasskeyOriginAndRpId(request);
+  const challenge = randomPasskeyChallenge();
+  const challengeId = await storage.createPasskeyChallenge('register', challenge, user.id, origin, rpId, 5 * 60 * 1000);
+  const existing = await storage.listPasskeysByUserId(user.id);
+  return jsonResponse({
+    challengeId,
+    publicKey: {
+      challenge,
+      rp: { id: rpId, name: 'NodeWarden' },
+      user: {
+        id: bytesToBase64Url(new TextEncoder().encode(user.id)),
+        name: user.email,
+        displayName: user.name || user.email,
+      },
+      pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+      timeout: 60000,
+      authenticatorSelection: { residentKey: 'preferred', userVerification: 'preferred' },
+      attestation: 'none',
+      excludeCredentials: existing.map((item) => ({ id: item.credentialId, type: 'public-key' })),
+    },
+  });
+}
+
+// POST /api/accounts/passkeys/register/verify
+export async function handlePasskeyRegisterVerify(request: Request, env: Env, userId: string): Promise<Response> {
+  const storage = new StorageService(env.DB);
+  let body: { challengeId?: string; name?: string; credential?: any; vaultEncKey?: string; vaultMacKey?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('Invalid JSON', 400);
+  }
+
+  const challengeData = await storage.consumePasskeyChallenge(String(body.challengeId || ''), 'register');
+  if (!challengeData || challengeData.userId !== userId) return errorResponse('Challenge expired', 400);
+
+  const credential = body.credential || {};
+  const response = credential.response || {};
+  const clientData = parseClientData(String(response.clientDataJSON || ''));
+  if (!clientData || clientData.challenge !== challengeData.challenge || clientData.origin !== challengeData.origin || clientData.type !== 'webauthn.create') {
+    return errorResponse('Invalid passkey registration response', 400);
+  }
+
+  const credentialId = String(credential.id || credential.rawId || '').trim();
+  const publicKeySpki = String(response.publicKey || '').trim();
+  const algorithm = Number(response.publicKeyAlgorithm || -7);
+  const name = String(body.name || '').trim().slice(0, 64) || 'Passkey';
+  if (!credentialId || !publicKeySpki || !body.vaultEncKey || !body.vaultMacKey) {
+    return errorResponse('Missing passkey fields', 400);
+  }
+  const current = await storage.listPasskeysByUserId(userId);
+  if (current.length >= 5) return errorResponse('At most 5 passkeys are allowed', 400);
+
+  try {
+    await storage.createPasskey({
+      userId,
+      credentialId,
+      publicKeySpki,
+      algorithm,
+      counter: readAuthenticatorCounter(String(response.authenticatorData || '')),
+      transports: Array.isArray(response.transports) ? response.transports.join(',') : null,
+      name,
+      rpId: challengeData.rpId,
+      vaultEncKey: String(body.vaultEncKey),
+      vaultMacKey: String(body.vaultMacKey),
+    });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+    if (msg.includes('unique')) return errorResponse('This passkey is already registered', 409);
+    throw error;
+  }
+
+  return jsonResponse({ success: true, object: 'passkey' });
+}
+
+// PUT /api/accounts/passkeys/:id
+export async function handlePasskeyRename(request: Request, env: Env, userId: string, passkeyId: string): Promise<Response> {
+  const storage = new StorageService(env.DB);
+  let body: { name?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('Invalid JSON', 400);
+  }
+  const name = String(body.name || '').trim().slice(0, 64);
+  if (!name) return errorResponse('Name is required', 400);
+  const updated = await storage.updatePasskeyName(userId, passkeyId, name);
+  if (!updated) return errorResponse('Passkey not found', 404);
+  return jsonResponse({ success: true });
+}
+
+// DELETE /api/accounts/passkeys/:id
+export async function handlePasskeyDelete(request: Request, env: Env, userId: string, passkeyId: string): Promise<Response> {
+  void request;
+  const storage = new StorageService(env.DB);
+  const deleted = await storage.deletePasskey(userId, passkeyId);
+  if (!deleted) return errorResponse('Passkey not found', 404);
+  return new Response(null, { status: 204 });
+}
+
+// POST /api/accounts/passkeys/unlock/options
+export async function handlePasskeyUnlockOptions(request: Request, env: Env, userId: string): Promise<Response> {
+  const storage = new StorageService(env.DB);
+  const { origin, rpId } = getPasskeyOriginAndRpId(request);
+  const challenge = randomPasskeyChallenge();
+  const challengeId = await storage.createPasskeyChallenge('unlock', challenge, userId, origin, rpId, 5 * 60 * 1000);
+  return jsonResponse({ challengeId, challenge, rpId, timeout: 60000, userVerification: 'preferred' });
+}
+
+// POST /api/accounts/passkeys/unlock/verify
+export async function handlePasskeyUnlockVerify(request: Request, env: Env, userId: string): Promise<Response> {
+  const storage = new StorageService(env.DB);
+  let body: { challengeId?: string; credential?: PasskeyAssertionRequest };
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('Invalid JSON', 400);
+  }
+  const challengeData = await storage.consumePasskeyChallenge(String(body.challengeId || ''), 'unlock');
+  if (!challengeData || challengeData.userId !== userId) return errorResponse('Challenge expired', 400);
+
+  const credential = body.credential || {};
+  const response = credential.response || {};
+  const clientData = parseClientData(String(response.clientDataJSON || ''));
+  if (!clientData || clientData.challenge !== challengeData.challenge || clientData.origin !== challengeData.origin || clientData.type !== 'webauthn.get') {
+    return errorResponse('Invalid passkey assertion', 400);
+  }
+
+  const passkey = await storage.getPasskeyByCredentialId(String(credential.id || credential.rawId || ''));
+  if (!passkey || passkey.userId !== userId) return errorResponse('Passkey not found', 404);
+  const verified = await verifyAssertionSignature({
+    algorithm: passkey.algorithm,
+    publicKeySpkiB64: passkey.publicKeySpki,
+    authenticatorDataB64u: String(response.authenticatorData || ''),
+    clientDataJSONB64u: String(response.clientDataJSON || ''),
+    signatureB64u: String(response.signature || ''),
+  });
+  if (!verified) return errorResponse('Invalid passkey signature', 400);
+  const nextCounter = readAuthenticatorCounter(String(response.authenticatorData || ''));
+  if (passkey.counter > 0 && nextCounter > 0 && nextCounter <= passkey.counter) {
+    return errorResponse('Passkey counter check failed', 400);
+  }
+  await storage.touchPasskeyUsage(passkey.id, nextCounter || passkey.counter);
+  return jsonResponse({ symEncKey: passkey.vaultEncKey, symMacKey: passkey.vaultMacKey });
 }
 
 // GET /api/accounts/revision-date

--- a/src/handlers/identity.ts
+++ b/src/handlers/identity.ts
@@ -14,6 +14,7 @@ import {
   buildAccountKeys,
   buildUserDecryptionOptions,
 } from '../utils/user-decryption';
+import { bytesToBase64Url, parseClientData, readAuthenticatorCounter, verifyAssertionSignature } from '../utils/passkey';
 
 const TWO_FACTOR_REMEMBER_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const TWO_FACTOR_PROVIDER_AUTHENTICATOR = 0;
@@ -476,4 +477,104 @@ export async function handleRevocation(request: Request, env: Env): Promise<Resp
   }
 
   return new Response(null, { status: 200 });
+}
+
+export async function handlePasskeyLoginOptions(request: Request, env: Env): Promise<Response> {
+  const storage = new StorageService(env.DB);
+  const url = new URL(request.url);
+  const challenge = bytesToBase64Url(crypto.getRandomValues(new Uint8Array(32)));
+  const challengeId = await storage.createPasskeyChallenge('login', challenge, null, url.origin, url.hostname, 5 * 60 * 1000);
+  return jsonResponse({ challengeId, challenge, rpId: url.hostname, timeout: 60000, userVerification: 'preferred' });
+}
+
+export async function handlePasskeyLoginVerify(request: Request, env: Env): Promise<Response> {
+  const storage = new StorageService(env.DB);
+  const auth = new AuthService(env);
+  let body: { challengeId?: string; credential?: any; twoFactorToken?: string; twoFactorProvider?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return identityErrorResponse('Invalid request payload', 'invalid_request', 400);
+  }
+  const challengeData = await storage.consumePasskeyChallenge(String(body.challengeId || ''), 'login');
+  if (!challengeData) return identityErrorResponse('Passkey challenge expired', 'invalid_grant', 400);
+
+  const credential = body.credential || {};
+  const response = credential.response || {};
+  const clientData = parseClientData(String(response.clientDataJSON || ''));
+  if (!clientData || clientData.challenge !== challengeData.challenge || clientData.origin !== challengeData.origin || clientData.type !== 'webauthn.get') {
+    return identityErrorResponse('Invalid passkey assertion', 'invalid_grant', 400);
+  }
+  const passkey = await storage.getPasskeyByCredentialId(String(credential.id || credential.rawId || ''));
+  if (!passkey) return identityErrorResponse('Passkey not registered', 'invalid_grant', 400);
+  const user = await storage.getUserById(passkey.userId);
+  if (!user || user.status !== 'active') return identityErrorResponse('Account is disabled', 'invalid_grant', 400);
+
+  const verified = await verifyAssertionSignature({
+    algorithm: passkey.algorithm,
+    publicKeySpkiB64: passkey.publicKeySpki,
+    authenticatorDataB64u: String(response.authenticatorData || ''),
+    clientDataJSONB64u: String(response.clientDataJSON || ''),
+    signatureB64u: String(response.signature || ''),
+  });
+  if (!verified) return identityErrorResponse('Invalid passkey signature', 'invalid_grant', 400);
+  const nextCounter = readAuthenticatorCounter(String(response.authenticatorData || ''));
+  if (passkey.counter > 0 && nextCounter > 0 && nextCounter <= passkey.counter) {
+    return identityErrorResponse('Passkey counter check failed', 'invalid_grant', 400);
+  }
+  await storage.touchPasskeyUsage(passkey.id, nextCounter || passkey.counter);
+
+  const effectiveTotpSecret = resolveTotpSecret(user.totpSecret);
+  if (effectiveTotpSecret) {
+    const provider = String(body.twoFactorProvider || '').trim();
+    const token = String(body.twoFactorToken || '').trim();
+    if (!provider || !token) return twoFactorRequiredResponse('Two factor required.', !!user.totpRecoveryCode);
+    if (provider === String(TWO_FACTOR_PROVIDER_AUTHENTICATOR)) {
+      const ok = await verifyTotpToken(effectiveTotpSecret, token);
+      if (!ok) return identityErrorResponse('Two-step token is invalid. Try again.', 'invalid_grant', 400);
+    } else if (
+      provider === TWO_FACTOR_PROVIDER_RECOVERY_CODE_RESPONSE ||
+      provider === String(TWO_FACTOR_PROVIDER_RECOVERY_CODE_LEGACY) ||
+      provider === String(TWO_FACTOR_PROVIDER_RECOVERY_CODE_ANDROID_REQUEST)
+    ) {
+      if (!recoveryCodeEquals(token, user.totpRecoveryCode)) {
+        return identityErrorResponse('Two-step token is invalid. Try again.', 'invalid_grant', 400);
+      }
+      user.totpSecret = null;
+      user.totpRecoveryCode = createRecoveryCode();
+      user.updatedAt = new Date().toISOString();
+      await storage.saveUser(user);
+      await storage.deleteRefreshTokensByUserId(user.id);
+    } else {
+      return identityErrorResponse('Two-step token is invalid. Try again.', 'invalid_grant', 400);
+    }
+  }
+
+  const accessToken = await auth.generateAccessToken(user, null);
+  const refreshToken = await auth.generateRefreshToken(user.id, null);
+  const responseBody: Record<string, unknown> = {
+    access_token: accessToken,
+    expires_in: LIMITS.auth.accessTokenTtlSeconds,
+    token_type: 'Bearer',
+    refresh_token: refreshToken,
+    Key: user.key,
+    PrivateKey: user.privateKey,
+    AccountKeys: buildAccountKeys(user),
+    accountKeys: buildAccountKeys(user),
+    Kdf: user.kdfType,
+    KdfIterations: user.kdfIterations,
+    KdfMemory: user.kdfMemory,
+    KdfParallelism: user.kdfParallelism,
+    ForcePasswordReset: false,
+    ResetMasterPassword: false,
+    MasterPasswordPolicy: { Object: 'masterPasswordPolicy' },
+    ApiUseKeyConnector: false,
+    scope: 'api offline_access',
+    unofficialServer: true,
+    UserDecryptionOptions: buildUserDecryptionOptions(user),
+    userDecryptionOptions: buildUserDecryptionOptions(user),
+    passkeySymEncKey: passkey.vaultEncKey,
+    passkeySymMacKey: passkey.vaultMacKey,
+  };
+  return jsonResponse(responseBody);
 }

--- a/src/router-authenticated.ts
+++ b/src/router-authenticated.ts
@@ -11,6 +11,13 @@ import {
   handleGetTotpStatus,
   handleSetTotpStatus,
   handleGetTotpRecoveryCode,
+  handleListPasskeys,
+  handlePasskeyRegisterOptions,
+  handlePasskeyRegisterVerify,
+  handlePasskeyRename,
+  handlePasskeyDelete,
+  handlePasskeyUnlockOptions,
+  handlePasskeyUnlockVerify,
 } from './handlers/accounts';
 import {
   handleGetCiphers,
@@ -109,6 +116,27 @@ export async function handleAuthenticatedRoute(
 
   if (path === '/api/accounts/revision-date' && method === 'GET') {
     return handleGetRevisionDate(request, env, userId);
+  }
+
+  if (path === '/api/accounts/passkeys' && method === 'GET') {
+    return handleListPasskeys(request, env, userId);
+  }
+  if (path === '/api/accounts/passkeys/register/options' && method === 'POST') {
+    return handlePasskeyRegisterOptions(request, env, userId);
+  }
+  if (path === '/api/accounts/passkeys/register/verify' && method === 'POST') {
+    return handlePasskeyRegisterVerify(request, env, userId);
+  }
+  if (path === '/api/accounts/passkeys/unlock/options' && method === 'POST') {
+    return handlePasskeyUnlockOptions(request, env, userId);
+  }
+  if (path === '/api/accounts/passkeys/unlock/verify' && method === 'POST') {
+    return handlePasskeyUnlockVerify(request, env, userId);
+  }
+  const passkeyMatch = path.match(/^\/api\/accounts\/passkeys\/([a-f0-9-]+)$/i);
+  if (passkeyMatch) {
+    if (method === 'PUT' || method === 'POST') return handlePasskeyRename(request, env, userId, passkeyMatch[1]);
+    if (method === 'DELETE') return handlePasskeyDelete(request, env, userId, passkeyMatch[1]);
   }
 
   if (path === '/api/accounts/verify-password' && method === 'POST') {

--- a/src/router-public.ts
+++ b/src/router-public.ts
@@ -8,7 +8,7 @@ import {
   handleDownloadSendFile,
 } from './handlers/sends';
 import { handleKnownDevice } from './handlers/devices';
-import { handleToken, handlePrelogin, handleRevocation } from './handlers/identity';
+import { handleToken, handlePrelogin, handleRevocation, handlePasskeyLoginOptions, handlePasskeyLoginVerify } from './handlers/identity';
 import {
   handleRegister,
   handleGetPasswordHint,
@@ -272,6 +272,12 @@ export async function handlePublicRoute(
 
   if (path === '/identity/connect/token' && method === 'POST') {
     return handleToken(request, env);
+  }
+  if (path === '/identity/passkeys/login/options' && method === 'POST') {
+    return handlePasskeyLoginOptions(request, env);
+  }
+  if (path === '/identity/passkeys/login/verify' && method === 'POST') {
+    return handlePasskeyLoginVerify(request, env);
   }
 
   if (path === '/api/devices/knowndevice' && method === 'GET') {

--- a/src/services/storage-schema.ts
+++ b/src/services/storage-schema.ts
@@ -88,6 +88,16 @@ const SCHEMA_STATEMENTS: readonly string[] = [
   'FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_trusted_two_factor_device_tokens_user_device ON trusted_two_factor_device_tokens(user_id, device_identifier)',
 
+  'CREATE TABLE IF NOT EXISTS passkeys (' +
+  'id TEXT PRIMARY KEY, user_id TEXT NOT NULL, credential_id TEXT NOT NULL UNIQUE, public_key_spki TEXT NOT NULL, algorithm INTEGER NOT NULL, counter INTEGER NOT NULL DEFAULT 0, transports TEXT, name TEXT NOT NULL, rp_id TEXT NOT NULL, vault_enc_key TEXT NOT NULL, vault_mac_key TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, last_used_at TEXT, ' +
+  'FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE)',
+  'CREATE INDEX IF NOT EXISTS idx_passkeys_user_updated ON passkeys(user_id, updated_at)',
+  'CREATE INDEX IF NOT EXISTS idx_passkeys_credential ON passkeys(credential_id)',
+
+  'CREATE TABLE IF NOT EXISTS passkey_challenges (' +
+  'id TEXT PRIMARY KEY, challenge TEXT NOT NULL, action TEXT NOT NULL, user_id TEXT, expires_at INTEGER NOT NULL, created_at TEXT NOT NULL, origin TEXT, rp_id TEXT)',
+  'CREATE INDEX IF NOT EXISTS idx_passkey_challenges_expires ON passkey_challenges(expires_at)',
+
   'CREATE TABLE IF NOT EXISTS api_rate_limits (' +
   'identifier TEXT NOT NULL, window_start INTEGER NOT NULL, count INTEGER NOT NULL, ' +
   'PRIMARY KEY (identifier, window_start))',

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -1,5 +1,6 @@
-import { User, Cipher, Folder, Attachment, Device, Invite, AuditLog, Send, TrustedDeviceTokenSummary, RefreshTokenRecord } from '../types';
+import { User, Cipher, Folder, Attachment, Device, Invite, AuditLog, Send, TrustedDeviceTokenSummary, RefreshTokenRecord, PasskeyCredential } from '../types';
 import { LIMITS } from '../config/limits';
+import { generateUUID } from '../utils/uuid';
 import { ensureStorageSchema } from './storage-schema';
 import {
   getConfigValue as getStoredConfigValue,
@@ -588,6 +589,106 @@ export class StorageService {
 
   async getTrustedTwoFactorDeviceTokenUserId(token: string, deviceIdentifier: string): Promise<string | null> {
     return findStoredTrustedTokenUserId(this.db, this.trustedTwoFactorTokenKey.bind(this), token, deviceIdentifier);
+  }
+
+  // --- Passkeys ---
+
+  async createPasskeyChallenge(action: string, challenge: string, userId: string | null, origin: string, rpId: string, ttlMs: number): Promise<string> {
+    const id = generateUUID();
+    const nowIso = new Date().toISOString();
+    await this.db
+      .prepare('INSERT INTO passkey_challenges(id, challenge, action, user_id, expires_at, created_at, origin, rp_id) VALUES(?, ?, ?, ?, ?, ?, ?, ?)')
+      .bind(id, challenge, action, userId, Date.now() + ttlMs, nowIso, origin, rpId)
+      .run();
+    return id;
+  }
+
+  async consumePasskeyChallenge(id: string, action: string): Promise<{ challenge: string; userId: string | null; origin: string; rpId: string } | null> {
+    const row = await this.db
+      .prepare('SELECT challenge, user_id, origin, rp_id, expires_at FROM passkey_challenges WHERE id = ? AND action = ?')
+      .bind(id, action)
+      .first<{ challenge: string; user_id: string | null; origin: string | null; rp_id: string | null; expires_at: number }>();
+    await this.db.prepare('DELETE FROM passkey_challenges WHERE id = ?').bind(id).run();
+    if (!row || row.expires_at < Date.now() || !row.origin || !row.rp_id) return null;
+    return { challenge: row.challenge, userId: row.user_id ?? null, origin: row.origin, rpId: row.rp_id };
+  }
+
+  async listPasskeysByUserId(userId: string): Promise<PasskeyCredential[]> {
+    const res = await this.db
+      .prepare('SELECT id, user_id, credential_id, public_key_spki, algorithm, counter, transports, name, rp_id, vault_enc_key, vault_mac_key, created_at, updated_at, last_used_at FROM passkeys WHERE user_id = ? ORDER BY updated_at DESC')
+      .bind(userId)
+      .all<any>();
+    return (res.results || []).map((row) => ({
+      id: row.id,
+      userId: row.user_id,
+      credentialId: row.credential_id,
+      publicKeySpki: row.public_key_spki,
+      algorithm: Number(row.algorithm || -7),
+      counter: Number(row.counter || 0),
+      transports: row.transports ?? null,
+      name: row.name,
+      rpId: row.rp_id,
+      vaultEncKey: row.vault_enc_key,
+      vaultMacKey: row.vault_mac_key,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      lastUsedAt: row.last_used_at ?? null,
+    }));
+  }
+
+  async getPasskeyByCredentialId(credentialId: string): Promise<PasskeyCredential | null> {
+    const row = await this.db
+      .prepare('SELECT id, user_id, credential_id, public_key_spki, algorithm, counter, transports, name, rp_id, vault_enc_key, vault_mac_key, created_at, updated_at, last_used_at FROM passkeys WHERE credential_id = ?')
+      .bind(credentialId)
+      .first<any>();
+    if (!row) return null;
+    return {
+      id: row.id,
+      userId: row.user_id,
+      credentialId: row.credential_id,
+      publicKeySpki: row.public_key_spki,
+      algorithm: Number(row.algorithm || -7),
+      counter: Number(row.counter || 0),
+      transports: row.transports ?? null,
+      name: row.name,
+      rpId: row.rp_id,
+      vaultEncKey: row.vault_enc_key,
+      vaultMacKey: row.vault_mac_key,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      lastUsedAt: row.last_used_at ?? null,
+    };
+  }
+
+  async createPasskey(record: Omit<PasskeyCredential, 'id' | 'createdAt' | 'updatedAt' | 'lastUsedAt'>): Promise<string> {
+    const id = generateUUID();
+    const now = new Date().toISOString();
+    await this.db
+      .prepare('INSERT INTO passkeys(id, user_id, credential_id, public_key_spki, algorithm, counter, transports, name, rp_id, vault_enc_key, vault_mac_key, created_at, updated_at, last_used_at) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
+      .bind(id, record.userId, record.credentialId, record.publicKeySpki, record.algorithm, record.counter, record.transports, record.name, record.rpId, record.vaultEncKey, record.vaultMacKey, now, now, null)
+      .run();
+    return id;
+  }
+
+  async updatePasskeyName(userId: string, passkeyId: string, name: string): Promise<boolean> {
+    const result = await this.db
+      .prepare('UPDATE passkeys SET name = ?, updated_at = ? WHERE id = ? AND user_id = ?')
+      .bind(name, new Date().toISOString(), passkeyId, userId)
+      .run();
+    return Number(result.meta.changes || 0) > 0;
+  }
+
+  async deletePasskey(userId: string, passkeyId: string): Promise<boolean> {
+    const result = await this.db.prepare('DELETE FROM passkeys WHERE id = ? AND user_id = ?').bind(passkeyId, userId).run();
+    return Number(result.meta.changes || 0) > 0;
+  }
+
+  async touchPasskeyUsage(passkeyId: string, nextCounter: number): Promise<void> {
+    const now = new Date().toISOString();
+    await this.db
+      .prepare('UPDATE passkeys SET counter = ?, updated_at = ?, last_used_at = ? WHERE id = ?')
+      .bind(nextCounter, now, now, passkeyId)
+      .run();
   }
 
   // --- Revision dates ---

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -245,6 +245,23 @@ export interface TrustedDeviceTokenSummary {
   tokenCount: number;
 }
 
+export interface PasskeyCredential {
+  id: string;
+  userId: string;
+  credentialId: string;
+  publicKeySpki: string;
+  algorithm: number;
+  counter: number;
+  transports: string | null;
+  name: string;
+  rpId: string;
+  vaultEncKey: string;
+  vaultMacKey: string;
+  createdAt: string;
+  updatedAt: string;
+  lastUsedAt: string | null;
+}
+
 export enum SendType {
   Text = 0,
   File = 1,

--- a/src/utils/passkey.ts
+++ b/src/utils/passkey.ts
@@ -1,0 +1,60 @@
+export function bytesToBase64Url(bytes: Uint8Array): string {
+  const base64 = btoa(String.fromCharCode(...bytes));
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+export function base64UrlToBytes(value: string): Uint8Array {
+  const normalized = String(value || '').replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized + '='.repeat((4 - (normalized.length % 4 || 4)) % 4);
+  const binary = atob(padded);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+
+export function parseClientData(clientDataJsonB64u: string): { challenge: string; origin: string; type: string } | null {
+  try {
+    const decoded = new TextDecoder().decode(base64UrlToBytes(clientDataJsonB64u));
+    const parsed = JSON.parse(decoded) as { challenge?: string; origin?: string; type?: string };
+    if (!parsed?.challenge || !parsed?.origin || !parsed?.type) return null;
+    return { challenge: parsed.challenge, origin: parsed.origin, type: parsed.type };
+  } catch {
+    return null;
+  }
+}
+
+export function readAuthenticatorCounter(authenticatorDataB64u: string): number {
+  const data = base64UrlToBytes(authenticatorDataB64u);
+  if (data.length < 37) return 0;
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  return view.getUint32(33, false);
+}
+
+export async function verifyAssertionSignature(args: {
+  algorithm: number;
+  publicKeySpkiB64: string;
+  authenticatorDataB64u: string;
+  clientDataJSONB64u: string;
+  signatureB64u: string;
+}): Promise<boolean> {
+  const algo = Number(args.algorithm);
+  if (algo !== -7) return false;
+
+  const publicKey = await crypto.subtle.importKey(
+    'spki',
+    Uint8Array.from(atob(args.publicKeySpkiB64), (c) => c.charCodeAt(0)),
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    false,
+    ['verify']
+  );
+
+  const authData = base64UrlToBytes(args.authenticatorDataB64u);
+  const clientData = base64UrlToBytes(args.clientDataJSONB64u);
+  const clientHash = new Uint8Array(await crypto.subtle.digest('SHA-256', clientData));
+  const signed = new Uint8Array(authData.length + clientHash.length);
+  signed.set(authData, 0);
+  signed.set(clientHash, authData.length);
+
+  const signature = base64UrlToBytes(args.signatureB64u);
+  return crypto.subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, publicKey, signature, signed);
+}

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -12,8 +12,13 @@ import {
   getAuthorizedDevices,
   getCurrentDeviceIdentifier,
   getPasswordHint,
+  listPasskeys,
+  registerPasskey,
+  renamePasskey,
+  deletePasskey,
   getTotpStatus,
   saveSession,
+  unlockWithPasskey,
 } from '@/lib/api/auth';
 import { listAdminInvites, listAdminUsers } from '@/lib/api/admin';
 import { buildSendShareKey, getSends } from '@/lib/api/send';
@@ -36,6 +41,7 @@ import {
   type CompletedLogin,
   readInitialAppBootstrapState,
   performPasswordLogin,
+  performPasskeyLogin,
   performRecoverTwoFactorLogin,
   performRegistration,
   performTotpLogin,
@@ -378,6 +384,29 @@ export default function App() {
     }
   }
 
+  async function handlePasskeyLogin() {
+    if (pendingAuthAction) return;
+    setPendingAuthAction('login');
+    try {
+      const result = await performPasskeyLogin();
+      if (result.kind === 'success') {
+        await finalizeLogin(result.login);
+        return;
+      }
+      if (result.kind === 'totp') {
+        setPendingTotp(result.pendingTotp);
+        setTotpCode('');
+        setRememberDevice(false);
+        return;
+      }
+      pushToast('error', result.message || t('txt_login_failed'));
+    } catch (error) {
+      pushToast('error', error instanceof Error ? error.message : t('txt_login_failed'));
+    } finally {
+      setPendingAuthAction(null);
+    }
+  }
+
   async function handleTotpVerify() {
     if (!pendingTotp) return;
     if (!totpCode.trim()) {
@@ -527,6 +556,24 @@ export default function App() {
     }
   }
 
+  async function handlePasskeyUnlock() {
+    if (pendingAuthAction) return;
+    if (!session) return;
+    setPendingAuthAction('unlock');
+    try {
+      const keys = await unlockWithPasskey(authedFetch);
+      const nextSession = { ...session, ...keys };
+      setSession(nextSession);
+      setPhase('app');
+      if (location === '/' || location === '/lock') navigate('/vault');
+      pushToast('success', t('txt_unlocked'));
+    } catch (error) {
+      pushToast('error', error instanceof Error ? error.message : 'Passkey unlock failed');
+    } finally {
+      setPendingAuthAction(null);
+    }
+  }
+
   function handleLock() {
     if (!session) return;
     const nextSession = { ...session };
@@ -555,6 +602,22 @@ export default function App() {
         logoutNow();
       },
     });
+  }
+
+  async function handleRegisterPasskey(name: string) {
+    if (!session?.symEncKey || !session?.symMacKey) throw new Error('Vault is locked');
+    await registerPasskey(authedFetch, name, session.symEncKey, session.symMacKey);
+    await passkeysQuery.refetch();
+  }
+
+  async function handleRenamePasskey(id: string, name: string) {
+    await renamePasskey(authedFetch, id, name);
+    await passkeysQuery.refetch();
+  }
+
+  async function handleDeletePasskey(id: string) {
+    await deletePasskey(authedFetch, id);
+    await passkeysQuery.refetch();
   }
 
   function renderPassiveOverlays() {
@@ -614,6 +677,11 @@ export default function App() {
   const authorizedDevicesQuery = useQuery({
     queryKey: ['authorized-devices', session?.accessToken],
     queryFn: () => getAuthorizedDevices(authedFetch),
+    enabled: phase === 'app' && !!session?.accessToken,
+  });
+  const passkeysQuery = useQuery({
+    queryKey: ['passkeys', session?.accessToken],
+    queryFn: () => listPasskeys(authedFetch),
     enabled: phase === 'app' && !!session?.accessToken,
   });
 
@@ -1139,6 +1207,10 @@ export default function App() {
     },
     onOpenDisableTotp: () => setDisableTotpOpen(true),
     onGetRecoveryCode: accountSecurityActions.getRecoveryCode,
+    passkeys: passkeysQuery.data || [],
+    onRegisterPasskey: handleRegisterPasskey,
+    onRenamePasskey: handleRenamePasskey,
+    onDeletePasskey: handleDeletePasskey,
     onRefreshAuthorizedDevices: accountSecurityActions.refreshAuthorizedDevices,
     onRevokeDeviceTrust: accountSecurityActions.openRevokeDeviceTrust,
     onRemoveDevice: accountSecurityActions.openRemoveDevice,
@@ -1210,8 +1282,10 @@ export default function App() {
           onChangeRegister={setRegisterValues}
           onChangeUnlock={setUnlockPassword}
           onSubmitLogin={() => void handleLogin()}
+          onSubmitPasskeyLogin={() => void handlePasskeyLogin()}
           onSubmitRegister={() => void handleRegister()}
           onSubmitUnlock={() => void handleUnlock()}
+          onSubmitPasskeyUnlock={() => void handlePasskeyUnlock()}
           onGotoLogin={() => {
             setPhase('login');
             navigate('/login');

--- a/webapp/src/components/AppMainRoutes.tsx
+++ b/webapp/src/components/AppMainRoutes.tsx
@@ -4,6 +4,7 @@ import { Link, Route, Switch } from 'wouter';
 import { ArrowUpDown, Cloud, LogOut, Settings as SettingsIcon, Shield, ShieldUser } from 'lucide-preact';
 import type { ImportAttachmentFile, ImportResultSummary } from '@/components/ImportPage';
 import type { AdminBackupImportResponse, AdminBackupRunResponse, AdminBackupSettings, RemoteBackupBrowserResponse } from '@/lib/api/backup';
+import type { AccountPasskey } from '@/lib/api/auth';
 import type { CiphersImportPayload } from '@/lib/api/vault';
 import { t } from '@/lib/i18n';
 import type { AdminInvite, AdminUser, AuthorizedDevice, Cipher, Folder as VaultFolder, Profile, Send, SendDraft, SessionState, VaultDraft } from '@/lib/types';
@@ -94,6 +95,10 @@ export interface AppMainRoutesProps {
   onEnableTotp: (secret: string, token: string) => Promise<void>;
   onOpenDisableTotp: () => void;
   onGetRecoveryCode: (masterPassword: string) => Promise<string>;
+  passkeys: AccountPasskey[];
+  onRegisterPasskey: (name: string) => Promise<void>;
+  onRenamePasskey: (id: string, name: string) => Promise<void>;
+  onDeletePasskey: (id: string) => Promise<void>;
   onRefreshAuthorizedDevices: () => Promise<void>;
   onRevokeDeviceTrust: (device: AuthorizedDevice) => void;
   onRemoveDevice: (device: AuthorizedDevice) => void;
@@ -225,6 +230,10 @@ export default function AppMainRoutes(props: AppMainRoutesProps) {
                 onOpenDisableTotp={props.onOpenDisableTotp}
                 onGetRecoveryCode={props.onGetRecoveryCode}
                 onNotify={props.onNotify}
+                passkeys={props.passkeys}
+                onRegisterPasskey={props.onRegisterPasskey}
+                onRenamePasskey={props.onRenamePasskey}
+                onDeletePasskey={props.onDeletePasskey}
               />
             </Suspense>
           </div>

--- a/webapp/src/components/AuthViews.tsx
+++ b/webapp/src/components/AuthViews.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'preact/hooks';
-import { ArrowLeft, Eye, EyeOff, LogIn, LogOut, Unlock, UserPlus } from 'lucide-preact';
+import { ArrowLeft, Eye, EyeOff, KeyRound, LogIn, LogOut, Unlock, UserPlus } from 'lucide-preact';
 import StandalonePageFrame from '@/components/StandalonePageFrame';
 import { t } from '@/lib/i18n';
 
@@ -32,6 +32,8 @@ interface AuthViewsProps {
   onSubmitLogin: () => void;
   onSubmitRegister: () => void;
   onSubmitUnlock: () => void;
+  onSubmitPasskeyLogin: () => void;
+  onSubmitPasskeyUnlock: () => void;
   onGotoLogin: () => void;
   onGotoRegister: () => void;
   onLogout: () => void;
@@ -105,6 +107,10 @@ export default function AuthViews(props: AuthViewsProps) {
             <button type="submit" className="btn btn-primary full" disabled={unlockBusy || !props.unlockReady}>
               <Unlock size={16} className="btn-icon" />
               {unlockBusy ? t('txt_unlocking') : t('txt_unlock')}
+            </button>
+            <button type="button" className="btn btn-secondary full" onClick={props.onSubmitPasskeyUnlock} disabled={unlockBusy}>
+              <KeyRound size={16} className="btn-icon" />
+              {t('Passkey Unlock')}
             </button>
             <div className="or">{t('txt_or')}</div>
             <button type="button" className="btn btn-secondary full" onClick={props.onLogout} disabled={unlockBusy}>
@@ -242,6 +248,10 @@ export default function AuthViews(props: AuthViewsProps) {
           <button type="submit" className="btn btn-primary full" disabled={loginBusy}>
             <LogIn size={16} className="btn-icon" />
             {loginBusy ? t('txt_logging_in') : t('txt_log_in')}
+          </button>
+          <button type="button" className="btn btn-secondary full" onClick={props.onSubmitPasskeyLogin} disabled={loginBusy}>
+            <KeyRound size={16} className="btn-icon" />
+            {t('Passkey Login')}
           </button>
           <div className="or">{t('txt_or')}</div>
           <button type="button" className="btn btn-secondary full" onClick={props.onGotoRegister} disabled={loginBusy}>

--- a/webapp/src/components/SettingsPage.tsx
+++ b/webapp/src/components/SettingsPage.tsx
@@ -3,6 +3,7 @@ import { Clipboard, KeyRound, RefreshCw, ShieldCheck, ShieldOff } from 'lucide-p
 import { copyTextToClipboard } from '@/lib/clipboard';
 import qrcode from 'qrcode-generator';
 import type { Profile } from '@/lib/types';
+import type { AccountPasskey } from '@/lib/api/auth';
 import { t } from '@/lib/i18n';
 
 interface SettingsPageProps {
@@ -14,6 +15,10 @@ interface SettingsPageProps {
   onOpenDisableTotp: () => void;
   onGetRecoveryCode: (masterPassword: string) => Promise<string>;
   onNotify?: (type: 'success' | 'error', text: string) => void;
+  passkeys: AccountPasskey[];
+  onRegisterPasskey: (name: string) => Promise<void>;
+  onRenamePasskey: (id: string, name: string) => Promise<void>;
+  onDeletePasskey: (id: string) => Promise<void>;
 }
 
 function randomBase32Secret(length: number): string {
@@ -47,6 +52,7 @@ export default function SettingsPage(props: SettingsPageProps) {
   const [totpLocked, setTotpLocked] = useState(props.totpEnabled);
   const [recoveryMasterPassword, setRecoveryMasterPassword] = useState('');
   const [recoveryCode, setRecoveryCode] = useState('');
+  const [passkeyName, setPasskeyName] = useState('');
 
   useEffect(() => {
     if (!props.totpEnabled) {
@@ -138,6 +144,40 @@ export default function SettingsPage(props: SettingsPageProps) {
           <KeyRound size={14} className="btn-icon" />
           {t('txt_change_password')}
         </button>
+      </section>
+
+      <section className="card">
+        <h3>Passkeys</h3>
+        <div className="field-grid">
+          <label className="field">
+            <span>Name</span>
+            <input className="input" value={passkeyName} maxLength={64} onInput={(e) => setPasskeyName((e.currentTarget as HTMLInputElement).value)} />
+          </label>
+          <div className="field">
+            <span>&nbsp;</span>
+            <button type="button" className="btn btn-primary" onClick={() => void props.onRegisterPasskey(passkeyName || 'Passkey')}>
+              Register Passkey
+            </button>
+          </div>
+        </div>
+        <div className="stack">
+          {props.passkeys.map((item) => (
+            <div key={item.id} className="card" style={{ margin: 0 }}>
+              <div className="field-grid">
+                <label className="field">
+                  <span>Name</span>
+                  <input className="input" defaultValue={item.name} onBlur={(e) => void props.onRenamePasskey(item.id, (e.currentTarget as HTMLInputElement).value)} />
+                </label>
+                <div className="field">
+                  <span>Last used</span>
+                  <div className="muted-inline">{item.lastUsedAt || 'Never'}</div>
+                </div>
+              </div>
+              <button type="button" className="btn btn-danger" onClick={() => void props.onDeletePasskey(item.id)}>Delete</button>
+            </div>
+          ))}
+          {!props.passkeys.length && <div className="muted-inline">No passkeys yet.</div>}
+        </div>
       </section>
 
       <section className="card">

--- a/webapp/src/lib/api/auth.ts
+++ b/webapp/src/lib/api/auth.ts
@@ -1,4 +1,5 @@
 import { bytesToBase64, decryptBw, encryptBw, hkdfExpand, pbkdf2 } from '../crypto';
+import { createPasskeyCredential, getPasskeyAssertion } from '../passkey';
 import { t } from '../i18n';
 import type { AuthorizedDevice } from '../types';
 import type {
@@ -24,6 +25,14 @@ export interface PreloginKdfConfig {
   kdfIterations: number;
   kdfMemory: number | null;
   kdfParallelism: number | null;
+}
+
+export interface AccountPasskey {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+  lastUsedAt: string | null;
 }
 
 function randomHex(length: number): string {
@@ -181,6 +190,77 @@ export async function loginWithPassword(
   }
   if (!resp.ok) return json;
   return json;
+}
+
+export async function loginWithPasskey(options?: { totpCode?: string; twoFactorProvider?: string }): Promise<TokenSuccess | TokenError> {
+  const optResp = await fetch('/identity/passkeys/login/options', { method: 'POST' });
+  const optJson = (await parseJson<any>(optResp)) || {};
+  if (!optResp.ok) return { error: 'passkey_options_failed' };
+  const credential = await getPasskeyAssertion(optJson);
+  const verifyResp = await fetch('/identity/passkeys/login/verify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      challengeId: optJson.challengeId,
+      credential,
+      twoFactorProvider: options?.twoFactorProvider,
+      twoFactorToken: options?.totpCode,
+    }),
+  });
+  return (await parseJson<TokenSuccess & TokenError>(verifyResp)) || {};
+}
+
+export async function listPasskeys(authedFetch: AuthedFetch): Promise<AccountPasskey[]> {
+  const resp = await authedFetch('/api/accounts/passkeys');
+  if (!resp.ok) throw new Error('Failed to load passkeys');
+  const body = await parseJson<{ data?: AccountPasskey[] }>(resp);
+  return body?.data || [];
+}
+
+export async function registerPasskey(authedFetch: AuthedFetch, name: string, symEncKey: string, symMacKey: string): Promise<void> {
+  const optionsResp = await authedFetch('/api/accounts/passkeys/register/options', { method: 'POST' });
+  if (!optionsResp.ok) throw new Error('Failed to start passkey registration');
+  const options = await parseJson<any>(optionsResp);
+  const credential = await createPasskeyCredential(options || {});
+  const verifyResp = await authedFetch('/api/accounts/passkeys/register/verify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ challengeId: options?.challengeId, name, credential, vaultEncKey: symEncKey, vaultMacKey: symMacKey }),
+  });
+  if (!verifyResp.ok) {
+    const body = await parseJson<TokenError>(verifyResp);
+    throw new Error(body?.error_description || body?.error || 'Failed to register passkey');
+  }
+}
+
+export async function renamePasskey(authedFetch: AuthedFetch, id: string, name: string): Promise<void> {
+  const resp = await authedFetch(`/api/accounts/passkeys/${encodeURIComponent(id)}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+  if (!resp.ok) throw new Error('Failed to rename passkey');
+}
+
+export async function deletePasskey(authedFetch: AuthedFetch, id: string): Promise<void> {
+  const resp = await authedFetch(`/api/accounts/passkeys/${encodeURIComponent(id)}`, { method: 'DELETE' });
+  if (!resp.ok && resp.status !== 204) throw new Error('Failed to delete passkey');
+}
+
+export async function unlockWithPasskey(authedFetch: AuthedFetch): Promise<{ symEncKey: string; symMacKey: string }> {
+  const optionsResp = await authedFetch('/api/accounts/passkeys/unlock/options', { method: 'POST' });
+  if (!optionsResp.ok) throw new Error('Failed to start passkey unlock');
+  const options = await parseJson<any>(optionsResp);
+  const credential = await getPasskeyAssertion(options || {});
+  const verifyResp = await authedFetch('/api/accounts/passkeys/unlock/verify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ challengeId: options?.challengeId, credential }),
+  });
+  if (!verifyResp.ok) throw new Error('Passkey unlock failed');
+  const body = await parseJson<{ symEncKey?: string; symMacKey?: string }>(verifyResp);
+  if (!body?.symEncKey || !body?.symMacKey) throw new Error('Passkey unlock failed');
+  return { symEncKey: body.symEncKey, symMacKey: body.symMacKey };
 }
 
 export async function refreshAccessToken(refreshToken: string): Promise<TokenSuccess | null> {

--- a/webapp/src/lib/app-auth.ts
+++ b/webapp/src/lib/app-auth.ts
@@ -4,6 +4,7 @@ import {
   getProfile,
   loadSession,
   loginWithPassword,
+  loginWithPasskey,
   refreshAccessToken,
   recoverTwoFactor,
   registerAccount,
@@ -229,7 +230,7 @@ export async function bootstrapAppSession(initial: InitialAppBootstrapState = re
 export async function completeLogin(
   token: TokenSuccess,
   email: string,
-  masterKey: Uint8Array
+  masterKey?: Uint8Array
 ): Promise<CompletedLogin> {
   const normalizedEmail = email.trim().toLowerCase();
   const baseSession: SessionState = {
@@ -245,12 +246,34 @@ export async function completeLogin(
   if (!profile.key) {
     throw new Error('Missing profile key');
   }
-  const keys = await unlockVaultKey(profile.key, masterKey);
+  let keys: { symEncKey: string; symMacKey: string };
+  const passkeySymEncKey = (token as any).passkeySymEncKey;
+  const passkeySymMacKey = (token as any).passkeySymMacKey;
+  if (passkeySymEncKey && passkeySymMacKey) {
+    keys = { symEncKey: String(passkeySymEncKey), symMacKey: String(passkeySymMacKey) };
+  } else if (masterKey) {
+    keys = await unlockVaultKey(profile.key, masterKey);
+  } else {
+    throw new Error('Missing vault unlock material');
+  }
   return {
     session: { ...baseSession, ...keys },
     profile,
     profilePromise: getProfile(tempFetch),
   };
+}
+
+export async function performPasskeyLogin(totpCode?: string, twoFactorProvider?: string): Promise<PasswordLoginResult> {
+  const token = await loginWithPasskey({ totpCode, twoFactorProvider });
+  if ('access_token' in token && token.access_token) {
+    const email = ((token as any).email as string | undefined) || '';
+    return { kind: 'success', login: await completeLogin(token, email) };
+  }
+  const tokenError = token as { TwoFactorProviders?: unknown; error_description?: string; error?: string };
+  if (tokenError.TwoFactorProviders) {
+    return { kind: 'totp', pendingTotp: { email: '', passwordHash: '', masterKey: new Uint8Array() } };
+  }
+  return { kind: 'error', message: tokenError.error_description || tokenError.error || 'Passkey login failed' };
 }
 
 export async function performPasswordLogin(
@@ -292,6 +315,14 @@ export async function performTotpLogin(
   totpCode: string,
   rememberDevice: boolean
 ): Promise<CompletedLogin> {
+  if (!pendingTotp.email || !pendingTotp.passwordHash) {
+    const token = await loginWithPasskey({ totpCode: totpCode.trim(), twoFactorProvider: '0' });
+    if ('access_token' in token && token.access_token) {
+      return completeLogin(token, '');
+    }
+    const tokenError = token as { error_description?: string; error?: string };
+    throw new Error(tokenError.error_description || tokenError.error || 'TOTP verify failed');
+  }
   const token = await loginWithPassword(pendingTotp.email, pendingTotp.passwordHash, {
     totpCode: totpCode.trim(),
     rememberDevice,

--- a/webapp/src/lib/passkey.ts
+++ b/webapp/src/lib/passkey.ts
@@ -1,0 +1,84 @@
+export function base64UrlToBytes(value: string): Uint8Array {
+  const normalized = String(value || '').replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized + '='.repeat((4 - (normalized.length % 4 || 4)) % 4);
+  const binary = atob(padded);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+
+export function bytesToBase64Url(bytes: ArrayBuffer | Uint8Array): string {
+  const data = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  const base64 = btoa(String.fromCharCode(...data));
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function normalizeTransport(transports?: readonly AuthenticatorTransport[] | null): string[] {
+  if (!Array.isArray(transports)) return [];
+  return transports.map((item) => String(item));
+}
+
+export async function createPasskeyCredential(options: any): Promise<any> {
+  const publicKey: PublicKeyCredentialCreationOptions = {
+    ...options.publicKey,
+    challenge: base64UrlToBytes(options.publicKey.challenge),
+    user: {
+      ...options.publicKey.user,
+      id: base64UrlToBytes(options.publicKey.user.id),
+    },
+    excludeCredentials: Array.isArray(options.publicKey.excludeCredentials)
+      ? options.publicKey.excludeCredentials.map((item: any) => ({ ...item, id: base64UrlToBytes(item.id) }))
+      : [],
+  };
+
+  const created = await navigator.credentials.create({ publicKey });
+  const credential = created as PublicKeyCredential;
+  const response = credential.response as AuthenticatorAttestationResponse;
+  const publicKeyBytes = response.getPublicKey();
+  const publicKeyAlgorithm = response.getPublicKeyAlgorithm();
+
+  return {
+    id: credential.id,
+    type: credential.type,
+    rawId: bytesToBase64Url(credential.rawId),
+    response: {
+      clientDataJSON: bytesToBase64Url(response.clientDataJSON),
+      attestationObject: bytesToBase64Url(response.attestationObject),
+      publicKey: publicKeyBytes ? btoa(String.fromCharCode(...new Uint8Array(publicKeyBytes))) : '',
+      publicKeyAlgorithm,
+      authenticatorData: response.getAuthenticatorData ? bytesToBase64Url(response.getAuthenticatorData()) : '',
+      transports: normalizeTransport(response.getTransports?.()),
+    },
+  };
+}
+
+export async function getPasskeyAssertion(options: {
+  challenge: string;
+  rpId: string;
+  timeout?: number;
+  userVerification?: UserVerificationRequirement;
+  allowCredentials?: Array<{ id: string; type?: string }>;
+}): Promise<any> {
+  const publicKey: PublicKeyCredentialRequestOptions = {
+    challenge: base64UrlToBytes(options.challenge),
+    rpId: options.rpId,
+    timeout: options.timeout,
+    userVerification: options.userVerification,
+    allowCredentials: Array.isArray(options.allowCredentials)
+      ? options.allowCredentials.map((item) => ({ id: base64UrlToBytes(item.id), type: 'public-key' as PublicKeyCredentialType }))
+      : undefined,
+  };
+  const credential = (await navigator.credentials.get({ publicKey })) as PublicKeyCredential;
+  const response = credential.response as AuthenticatorAssertionResponse;
+  return {
+    id: credential.id,
+    type: credential.type,
+    rawId: bytesToBase64Url(credential.rawId),
+    response: {
+      clientDataJSON: bytesToBase64Url(response.clientDataJSON),
+      authenticatorData: bytesToBase64Url(response.authenticatorData),
+      signature: bytesToBase64Url(response.signature),
+      userHandle: response.userHandle ? bytesToBase64Url(response.userHandle) : null,
+    },
+  };
+}

--- a/webapp/src/lib/types.ts
+++ b/webapp/src/lib/types.ts
@@ -290,6 +290,8 @@ export interface TokenSuccess {
   unofficialServer?: boolean;
   UserDecryptionOptions?: unknown;
   userDecryptionOptions?: unknown;
+  passkeySymEncKey?: string;
+  passkeySymMacKey?: string;
 }
 
 export interface TokenError {


### PR DESCRIPTION
### Motivation
- Add first-factor Passkey (WebAuthn) support so users can sign in or unlock the vault without entering email/password, while still enforcing TOTP when configured. 
- Provide per-account Passkey management (register/list/rename/delete) and persist necessary server-side state for challenges and credentials. 

### Description
- Database and types: add `passkeys` and `passkey_challenges` tables and a new `PasskeyCredential` type in `src/types`; migration updated (`migrations/0001_init.sql`) and schema code updated (`src/services/storage-schema.ts`).
- Storage layer: add passkey lifecycle methods in `StorageService` (`createPasskeyChallenge`, `consumePasskeyChallenge`, `listPasskeysByUserId`, `getPasskeyByCredentialId`, `createPasskey`, `updatePasskeyName`, `deletePasskey`, `touchPasskeyUsage`) in `src/services/storage.ts`.
- Handlers / API: implement account endpoints for listing/registering/renaming/deleting passkeys and unlock flow (`/api/accounts/passkeys*`) in `src/handlers/accounts.ts`, and public passkey login endpoints (`/identity/passkeys/login/options` and `/identity/passkeys/login/verify`) in `src/handlers/identity.ts` that issue normal access/refresh tokens and return passkey-bound vault keys when appropriate.
- Utilities: add WebAuthn helpers and ES256 assertion verification in `src/utils/passkey.ts` and corresponding browser helpers in `webapp/src/lib/passkey.ts`.
- Frontend integration: add passkey APIs in `webapp/src/lib/api/auth.ts` (`loginWithPasskey`, `listPasskeys`, `registerPasskey`, `renamePasskey`, `deletePasskey`, `unlockWithPasskey`) and wire UI and flows: login and lock screens get Passkey buttons (`webapp/src/components/AuthViews.tsx`), settings page gets Passkey management UI (`webapp/src/components/SettingsPage.tsx`), application orchestration updated in `webapp/src/lib/app-auth.ts` and `webapp/src/App.tsx`, and routes updated (`src/router-authenticated.ts`, `src/router-public.ts`).
- Vault unlock: passkey flows can return passkey-bound vault symmetric keys and `app-auth` is updated to accept passkey-provided keys when completing login/unlock.
- Limit: registration enforces a maximum of 5 passkeys per account.

### Testing
- Built the web frontend: ran `npm run build` (Vite) and the build completed successfully.
- Type-check: ran `npx tsc -p tsconfig.json --noEmit` and TypeScript checked without errors.
- No additional automated unit tests were added; manual validation steps exercised the build and static type checks and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69caa843945c8320be61a73d4ac8aee2)