### PR TITLE
feat: 添加请求的 URL 规范化，解决 Keyguard 兼容问题

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,15 @@ let dbInitialized = false;
 let dbInitError: string | null = null;
 let dbInitPromise: Promise<void> | null = null;
 
+function normalizeRequestUrl(request: Request): Request {
+  const url = new URL(request.url);
+  const normalizedPathname = url.pathname.length <= 1 ? url.pathname : url.pathname.replace(/\/+$/, '');
+  if (normalizedPathname === url.pathname) return request;
+
+  url.pathname = normalizedPathname;
+  return new Request(url.toString(), request);
+}
+
 function isWorkerHandledPath(path: string): boolean {
   return (
     path.startsWith('/api/') ||
@@ -56,9 +65,10 @@ async function ensureDatabaseInitialized(env: Env): Promise<void> {
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     void ctx;
-    const assetResponse = await maybeServeAsset(request, env);
+    const normalizedRequest = normalizeRequestUrl(request);
+    const assetResponse = await maybeServeAsset(normalizedRequest, env);
     if (assetResponse) {
-      return applyCors(request, assetResponse);
+      return applyCors(normalizedRequest, assetResponse);
     }
 
     await ensureDatabaseInitialized(env);
@@ -76,11 +86,11 @@ export default {
         },
         500
       );
-      return applyCors(request, resp);
+      return applyCors(normalizedRequest, resp);
     }
 
-    const resp = await handleRequest(request, env);
-    return applyCors(request, resp);
+    const resp = await handleRequest(normalizedRequest, env);
+    return applyCors(normalizedRequest, resp);
   },
 
   async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {


### PR DESCRIPTION
## 概述

添加了Keyguard兼容，可关闭以下 issue ：

https://github.com/shuaiplus/nodewarden/issues/32

## 修改内容

- `src\index.ts` ，在 fetch 入口处对 Request 的 url 进行规范化，当长度不小于1时，去除结尾的 `/`

## 问题分析

Keyguard 的路径生成逻辑在 [ServerEnvApi.kt](https://github.com/AChep/keyguard-app/blob/a7e0623dbe487825b0c5be55b95696dcfe2c6832/common/src/commonMain/kotlin/com/artemchep/keyguard/provider/bitwarden/api/builder/ServerEnvApi.kt) 里，它生成的所有资源根路径均带有 `/`，如 `.../ciphers/`, `...folders/`，而这些路径不仅用于拼接，还直接用于调用，因此部分调用的路径以 `/` 结尾。

