### PR TITLE
fix: advertise fido2-vault-credentials in /api/config for extension passkey UX

### DIFF
--- a/src/router-public.ts
+++ b/src/router-public.ts
@@ -102,11 +102,15 @@ function buildConfigResponse(origin: string) {
     settings: {
       disableUserRegistration: false,
     },
+    experimentalClientFeatureFlags: ['fido2-vault-credentials'],
     _icon_service_url: buildIconServiceTemplate(origin),
     _icon_service_csp: buildIconServiceCsp(origin),
     featureStates: {
       'duo-redirect': true,
       'email-verification': true,
+      // Browser extensions only enable passkey vault storage/login UX when this
+      // server capability flag is exposed in /api/config.
+      'fido2-vault-credentials': true,
       'pm-19051-send-email-verification': false,
       'pm-19148-innovation-archive': true,
       'unauth-ui-refresh': true,


### PR DESCRIPTION
### Motivation
- Ensure Bitwarden browser extensions detect that the server supports storing/using passkeys in the vault so the extension can surface its passkey UX instead of letting browsers fall back to native/system passkey prompts.

### Description
- Add `experimentalClientFeatureFlags: ['fido2-vault-credentials']` and enable `'fido2-vault-credentials': true` inside `featureStates` in the `/api/config` response implemented in `src/router-public.ts`.

### Testing
- Ran `npm run build` to build the web client and it completed successfully.
- Ran `npx tsc -p tsconfig.json --noEmit` for TypeScript checks and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cbd7ed437483209d997813d6c7387b)