### PR TITLE
Fix WebAuthn passkey authenticator selection for browser extension compatibility

### DIFF
--- a/src/handlers/passkeys.ts
+++ b/src/handlers/passkeys.ts
@@ -12,6 +12,30 @@ import { isTotpEnabled, verifyTotpToken } from '../utils/totp';
 const PASSKEY_MAX = 5;
 const CHALLENGE_TTL_MS = 5 * 60 * 1000;
 const TWO_FACTOR_PROVIDER_AUTHENTICATOR = 0;
+const WEBAUTHN_TRANSPORTS = ['usb', 'nfc', 'ble', 'hybrid', 'internal'] as const;
+
+type WebAuthnTransport = (typeof WEBAUTHN_TRANSPORTS)[number];
+
+function normalizeTransports(input: unknown): WebAuthnTransport[] {
+  if (!Array.isArray(input)) return [];
+  const unique = new Set<WebAuthnTransport>();
+  for (const item of input) {
+    const normalized = String(item || '').trim().toLowerCase();
+    if ((WEBAUTHN_TRANSPORTS as readonly string[]).includes(normalized)) {
+      unique.add(normalized as WebAuthnTransport);
+    }
+  }
+  return Array.from(unique);
+}
+
+function parseStoredTransports(input: string | null): WebAuthnTransport[] {
+  if (!input) return [];
+  try {
+    return normalizeTransports(JSON.parse(input));
+  } catch {
+    return [];
+  }
+}
 
 function rpIdFromUrl(url: string): string {
   return new URL(url).hostname;
@@ -74,6 +98,7 @@ export async function handleBeginPasskeyRegistration(request: Request, env: Env,
       },
       pubKeyCredParams: [{ type: 'public-key', alg: -7 }, { type: 'public-key', alg: -257 }],
       authenticatorSelection: {
+        authenticatorAttachment: 'cross-platform',
         residentKey: 'required',
         userVerification: 'preferred',
       },
@@ -94,6 +119,7 @@ export async function handleFinishPasskeyRegistration(request: Request, env: Env
       id?: string;
       response?: {
         clientDataJSON?: string;
+        transports?: string[];
       };
     };
   };
@@ -102,6 +128,7 @@ export async function handleFinishPasskeyRegistration(request: Request, env: Env
   const wrappedVaultKeys = String(body.wrappedVaultKeys || '').trim();
   const credentialId = String(body.credential?.id || '').trim();
   const clientData = String(body.credential?.response?.clientDataJSON || '').trim();
+  const transports = normalizeTransports(body.credential?.response?.transports);
 
   if (!challengeId || !name || !wrappedVaultKeys || !credentialId || !clientData) {
     return errorResponse('Invalid request payload', 400);
@@ -125,7 +152,7 @@ export async function handleFinishPasskeyRegistration(request: Request, env: Env
     credentialId,
     publicKey: 'client-asserted',
     counter: 0,
-    transports: null,
+    transports: transports.length ? JSON.stringify(transports) : null,
     name: name.slice(0, 100),
     wrappedVaultKeys,
     createdAt: now,
@@ -171,7 +198,10 @@ export async function handleBeginPasskeyLogin(request: Request, env: Env): Promi
       rpId: rpIdFromUrl(request.url),
       timeout: 60000,
       userVerification: 'preferred',
-      allowCredentials: passkeys.map((pk) => ({ type: 'public-key', id: pk.credentialId })),
+      allowCredentials: passkeys.map((pk) => {
+        const transports = parseStoredTransports(pk.transports);
+        return { type: 'public-key', id: pk.credentialId, transports: transports.length ? transports : [...WEBAUTHN_TRANSPORTS] };
+      }),
     },
   });
 }

--- a/webapp/src/lib/passkey.ts
+++ b/webapp/src/lib/passkey.ts
@@ -42,6 +42,7 @@ export async function createPasskeyCredential(publicKey: Record<string, any>): P
     response: {
       clientDataJSON: bytesToBase64Url(response.clientDataJSON),
       attestationObject: bytesToBase64Url(response.attestationObject),
+      transports: typeof response.getTransports === 'function' ? response.getTransports() : [],
     },
   };
 }


### PR DESCRIPTION
### Motivation
- Make passkey registration/login behave more like Bitwarden official server so browser extensions (external authenticators) are discovered instead of falling back to OS platform passkey prompts.
- Provide deterministic, server-side transport hints so browsers/extensions can match credentials reliably across browsers and platforms.
- Avoid any new configurable variables; use a locked set of standard WebAuthn transports.

### Description
- Add a locked transport whitelist `WEBAUTHN_TRANSPORTS = ['usb','nfc','ble','hybrid','internal']` and implement `normalizeTransports`/`parseStoredTransports` to strictly validate and normalize transports on the server in `src/handlers/passkeys.ts`.
- Set `authenticatorSelection.authenticatorAttachment` to `"cross-platform"` in the registration payload to favor external/extension authenticators during `handleBeginPasskeyRegistration` in `src/handlers/passkeys.ts`.
- Capture `AuthenticatorAttestationResponse.getTransports()` from the client and persist `credential.response.transports` (serialized) when registering a passkey in `handleFinishPasskeyRegistration` in `src/handlers/passkeys.ts`.
- Include transport hints in `allowCredentials` for login (`handleBeginPasskeyLogin`) using stored transports or falling back to the locked full transport list so browsers/extensions can better match the right authenticator in `src/handlers/passkeys.ts`.
- Update the webapp to return attestation transports by adding `transports: typeof response.getTransports === 'function' ? response.getTransports() : []` in `webapp/src/lib/passkey.ts` so transports flow end-to-end from client to server.

### Testing
- Ran the production webapp build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cbdd0a1ff48320ab60f312b4c68972)