### PR TITLE
fix: allow extension passkey provider on NodeWarden domain

### DIFF
--- a/src/handlers/identity.ts
+++ b/src/handlers/identity.ts
@@ -300,7 +300,7 @@ export async function handleToken(request: Request, env: Env): Promise<Response>
       },
       ApiUseKeyConnector: false,
       scope: 'api offline_access',
-      unofficialServer: true,
+      unofficialServer: false,
       UserDecryptionOptions: buildUserDecryptionOptions(user),
       userDecryptionOptions: buildUserDecryptionOptions(user),
     };
@@ -355,7 +355,7 @@ export async function handleToken(request: Request, env: Env): Promise<Response>
       expires_in: LIMITS.auth.sendAccessTokenTtlSeconds,
       token_type: 'Bearer',
       scope: 'api.send',
-      unofficialServer: true,
+      unofficialServer: false,
     });
   } else if (grantType === 'refresh_token') {
     const refreshLimit = await rateLimit.consumeBudget(
@@ -411,7 +411,7 @@ export async function handleToken(request: Request, env: Env): Promise<Response>
       },
       ApiUseKeyConnector: false,
       scope: 'api offline_access',
-      unofficialServer: true,
+      unofficialServer: false,
       UserDecryptionOptions: buildUserDecryptionOptions(user),
       userDecryptionOptions: buildUserDecryptionOptions(user),
     };

--- a/src/handlers/passkeys.ts
+++ b/src/handlers/passkeys.ts
@@ -256,7 +256,7 @@ export async function handleFinishPasskeyLogin(request: Request, env: Env): Prom
     MasterPasswordPolicy: { Object: 'masterPasswordPolicy' },
     ApiUseKeyConnector: false,
     scope: 'api offline_access',
-    unofficialServer: true,
+    unofficialServer: false,
     UserDecryptionOptions: buildUserDecryptionOptions(user),
     userDecryptionOptions: buildUserDecryptionOptions(user),
     VaultKeys: vaultKeys,


### PR DESCRIPTION
## Summary
- changed OAuth/token payloads to return `unofficialServer: false`
- updated both password/refresh/send token responses and passkey-login token response
- aligns NodeWarden responses with official-server behavior expected by Bitwarden browser extensions when deciding passkey provider behavior

## Files
- `src/handlers/identity.ts`
- `src/handlers/passkeys.ts`

## Why
When the extension account is connected to NodeWarden, passkey flows on the NodeWarden site were falling back to the OS/system passkey UI instead of invoking the Bitwarden extension passkey UI. This patch removes the self-hosted/unofficial flag from token responses so extension behavior matches official-server expectations for in-browser passkey provider prompting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cbe394e7888320970355fc8ce53544)