### PR TITLE
refactor: 使用 waitUntil 优化 WebSocket 通知推送，不阻塞 API 响应返回

### DIFF
--- a/src/durable/notifications-hub.ts
+++ b/src/durable/notifications-hub.ts
@@ -1,4 +1,4 @@
-import { DurableObject } from 'cloudflare:workers';
+import { DurableObject, waitUntil } from 'cloudflare:workers';
 import type { Env } from '../types';
 
 const SIGNALR_RECORD_SEPARATOR = 0x1e;
@@ -362,21 +362,21 @@ export class NotificationsHub extends DurableObject<Env> {
   }
 }
 
-export async function notifyUserVaultSync(
+export function notifyUserVaultSync(
   env: Env,
   userId: string,
   revisionDate: string,
   contextId?: string | null
-): Promise<void> {
-  return notifyUserUpdate(env, userId, SIGNALR_UPDATE_TYPE_SYNC_VAULT, revisionDate, contextId ?? null, null);
+): void {
+  waitUntil(notifyUserUpdate(env, userId, SIGNALR_UPDATE_TYPE_SYNC_VAULT, revisionDate, contextId ?? null, null));
 }
 
-export async function notifyUserLogout(
+export function notifyUserLogout(
   env: Env,
   userId: string,
   targetDeviceIdentifier?: string | null
-): Promise<void> {
-  return notifyUserUpdate(env, userId, SIGNALR_UPDATE_TYPE_LOG_OUT, new Date().toISOString(), null, targetDeviceIdentifier ?? null);
+): void {
+  waitUntil(notifyUserUpdate(env, userId, SIGNALR_UPDATE_TYPE_LOG_OUT, new Date().toISOString(), null, targetDeviceIdentifier ?? null));
 }
 
 export async function getOnlineUserDevices(env: Env, userId: string): Promise<string[]> {

--- a/src/handlers/attachments.ts
+++ b/src/handlers/attachments.ts
@@ -21,13 +21,13 @@ import {
   putBlobObject,
 } from '../services/blob-store';
 
-async function notifyVaultSyncForRequest(
+function notifyVaultSyncForRequest(
   request: Request,
   env: Env,
   userId: string,
   revisionDate: string
-): Promise<void> {
-  await notifyUserVaultSync(env, userId, revisionDate, readActingDeviceIdentifier(request));
+): void {
+  notifyUserVaultSync(env, userId, revisionDate, readActingDeviceIdentifier(request));
 }
 
 // Format file size to human readable
@@ -93,7 +93,7 @@ async function processAttachmentUpload(
 
   const revisionInfo = await storage.updateCipherRevisionDate(cipherId);
   if (revisionInfo) {
-    await notifyVaultSyncForRequest(request, env, revisionInfo.userId, revisionInfo.revisionDate);
+    notifyVaultSyncForRequest(request, env, revisionInfo.userId, revisionInfo.revisionDate);
   }
 
   return new Response(null, { status: 201 });
@@ -153,7 +153,7 @@ export async function handleCreateAttachment(
   // Update cipher revision date
   const revisionInfo = await storage.updateCipherRevisionDate(cipherId);
   if (revisionInfo) {
-    await notifyVaultSyncForRequest(request, env, revisionInfo.userId, revisionInfo.revisionDate);
+    notifyVaultSyncForRequest(request, env, revisionInfo.userId, revisionInfo.revisionDate);
   }
 
   // Get updated cipher for response
@@ -324,7 +324,7 @@ export async function handleUpdateAttachmentMetadata(
   await storage.saveAttachment(attachment);
   const revisionInfo = await storage.updateCipherRevisionDate(cipherId);
   if (revisionInfo) {
-    await notifyVaultSyncForRequest(request, env, revisionInfo.userId, revisionInfo.revisionDate);
+    notifyVaultSyncForRequest(request, env, revisionInfo.userId, revisionInfo.revisionDate);
   }
 
   return jsonResponse({
@@ -432,7 +432,7 @@ export async function handleDeleteAttachment(
   // Update cipher revision date
   const revisionInfo = await storage.updateCipherRevisionDate(cipherId);
   if (revisionInfo) {
-    await notifyVaultSyncForRequest(request, env, revisionInfo.userId, revisionInfo.revisionDate);
+    notifyVaultSyncForRequest(request, env, revisionInfo.userId, revisionInfo.revisionDate);
   }
 
   // Get updated cipher for response

--- a/src/handlers/ciphers.ts
+++ b/src/handlers/ciphers.ts
@@ -24,13 +24,13 @@ function normalizeOptionalId(value: unknown): string | null {
   return normalized ? normalized : null;
 }
 
-async function notifyVaultSyncForRequest(
+function notifyVaultSyncForRequest(
   request: Request,
   env: Env,
   userId: string,
   revisionDate: string
-): Promise<void> {
-  await notifyUserVaultSync(env, userId, revisionDate, readActingDeviceIdentifier(request));
+): void {
+  notifyUserVaultSync(env, userId, revisionDate, readActingDeviceIdentifier(request));
 }
 
 function getAliasedProp(source: any, aliases: string[]): { present: boolean; value: any } {
@@ -304,7 +304,7 @@ export async function handleCreateCipher(request: Request, env: Env, userId: str
 
   await storage.saveCipher(cipher);
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
 
   return jsonResponse(
     cipherToResponse(cipher, []),
@@ -398,7 +398,7 @@ export async function handleUpdateCipher(request: Request, env: Env, userId: str
 
   await storage.saveCipher(cipher);
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
   const attachments = await storage.getAttachmentsByCipher(cipher.id);
 
   return jsonResponse(
@@ -421,7 +421,7 @@ export async function handleDeleteCipher(request: Request, env: Env, userId: str
   syncCipherComputedAliases(cipher);
   await storage.saveCipher(cipher);
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
 
   return jsonResponse(
     cipherToResponse(cipher, [])
@@ -445,7 +445,7 @@ export async function handleDeleteCipherCompat(request: Request, env: Env, userI
     await deleteAllAttachmentsForCipher(env, id);
     await storage.deleteCipher(id, userId);
     const revisionDate = await storage.updateRevisionDate(userId);
-    await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+    notifyVaultSyncForRequest(request, env, userId, revisionDate);
     return new Response(null, { status: 204 });
   }
 
@@ -466,7 +466,7 @@ export async function handlePermanentDeleteCipher(request: Request, env: Env, us
 
   await storage.deleteCipher(id, userId);
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
 
   return new Response(null, { status: 204 });
 }
@@ -485,7 +485,7 @@ export async function handleRestoreCipher(request: Request, env: Env, userId: st
   syncCipherComputedAliases(cipher);
   await storage.saveCipher(cipher);
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
 
   return jsonResponse(
     cipherToResponse(cipher, [])
@@ -524,7 +524,7 @@ export async function handlePartialUpdateCipher(request: Request, env: Env, user
 
   await storage.saveCipher(cipher);
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
 
   return jsonResponse(
     cipherToResponse(cipher, [])
@@ -554,7 +554,7 @@ export async function handleBulkMoveCiphers(request: Request, env: Env, userId: 
 
   const revisionDate = await storage.bulkMoveCiphers(body.ids, folderId, userId);
   if (revisionDate) {
-    await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+    notifyVaultSyncForRequest(request, env, userId, revisionDate);
   }
 
   return new Response(null, { status: 204 });
@@ -600,7 +600,7 @@ export async function handleArchiveCipher(request: Request, env: Env, userId: st
   normalizeCipherForStorage(cipher);
   await storage.saveCipher(cipher);
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
 
   const attachments = await storage.getAttachmentsByCipher(cipher.id);
   return jsonResponse(
@@ -622,7 +622,7 @@ export async function handleUnarchiveCipher(request: Request, env: Env, userId: 
   normalizeCipherForStorage(cipher);
   await storage.saveCipher(cipher);
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
 
   const attachments = await storage.getAttachmentsByCipher(cipher.id);
   return jsonResponse(
@@ -648,7 +648,7 @@ export async function handleBulkArchiveCiphers(request: Request, env: Env, userI
 
   const revisionDate = await storage.bulkArchiveCiphers(ids, userId);
   if (revisionDate) {
-    await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+    notifyVaultSyncForRequest(request, env, userId, revisionDate);
   }
 
   return buildCipherListResponse(request, storage, userId, ids);
@@ -672,7 +672,7 @@ export async function handleBulkUnarchiveCiphers(request: Request, env: Env, use
 
   const revisionDate = await storage.bulkUnarchiveCiphers(ids, userId);
   if (revisionDate) {
-    await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+    notifyVaultSyncForRequest(request, env, userId, revisionDate);
   }
 
   return buildCipherListResponse(request, storage, userId, ids);
@@ -695,7 +695,7 @@ export async function handleBulkDeleteCiphers(request: Request, env: Env, userId
 
   const revisionDate = await storage.bulkSoftDeleteCiphers(body.ids, userId);
   if (revisionDate) {
-    await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+    notifyVaultSyncForRequest(request, env, userId, revisionDate);
   }
 
   return new Response(null, { status: 204 });
@@ -718,7 +718,7 @@ export async function handleBulkRestoreCiphers(request: Request, env: Env, userI
 
   const revisionDate = await storage.bulkRestoreCiphers(body.ids, userId);
   if (revisionDate) {
-    await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+    notifyVaultSyncForRequest(request, env, userId, revisionDate);
   }
 
   return new Response(null, { status: 204 });
@@ -750,7 +750,7 @@ export async function handleBulkPermanentDeleteCiphers(request: Request, env: En
 
   const revisionDate = await storage.bulkDeleteCiphers(ids, userId);
   if (revisionDate) {
-    await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+    notifyVaultSyncForRequest(request, env, userId, revisionDate);
   }
 
   return new Response(null, { status: 204 });

--- a/src/handlers/devices.ts
+++ b/src/handlers/devices.ts
@@ -284,7 +284,7 @@ export async function handleDeleteDevice(
   await storage.deleteRefreshTokensByDevice(userId, normalized);
   const deleted = await storage.deleteDevice(userId, normalized);
   if (deleted) {
-    await notifyUserLogout(env, userId, normalized);
+    notifyUserLogout(env, userId, normalized);
   }
   return jsonResponse({ success: deleted });
 }
@@ -327,7 +327,7 @@ export async function handleDeleteAllDevices(request: Request, env: Env, userId:
   user.securityStamp = generateUUID();
   user.updatedAt = new Date().toISOString();
   await storage.saveUser(user);
-  await notifyUserLogout(env, userId, null);
+  notifyUserLogout(env, userId, null);
   return jsonResponse({ success: true, removedTrusted, removedSessions: removedSessions ?? 0, removedDevices });
 }
 
@@ -458,7 +458,7 @@ export async function handleDeactivateDevice(
   await storage.deleteRefreshTokensByDevice(userId, normalized);
   const deleted = await storage.deleteDevice(userId, normalized);
   if (deleted) {
-    await notifyUserLogout(env, userId, normalized);
+    notifyUserLogout(env, userId, normalized);
   }
   return jsonResponse({ success: deleted });
 }

--- a/src/handlers/folders.ts
+++ b/src/handlers/folders.ts
@@ -6,13 +6,13 @@ import { readActingDeviceIdentifier } from '../utils/device';
 import { generateUUID } from '../utils/uuid';
 import { parsePagination, encodeContinuationToken } from '../utils/pagination';
 
-async function notifyVaultSyncForRequest(
+function notifyVaultSyncForRequest(
   request: Request,
   env: Env,
   userId: string,
   revisionDate: string
-): Promise<void> {
-  await notifyUserVaultSync(env, userId, revisionDate, readActingDeviceIdentifier(request));
+): void {
+  notifyUserVaultSync(env, userId, revisionDate, readActingDeviceIdentifier(request));
 }
 
 // Convert internal folder to API response format
@@ -88,7 +88,7 @@ export async function handleCreateFolder(request: Request, env: Env, userId: str
 
   await storage.saveFolder(folder);
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
 
   return jsonResponse(folderToResponse(folder), 200);
 }
@@ -116,7 +116,7 @@ export async function handleUpdateFolder(request: Request, env: Env, userId: str
 
   await storage.saveFolder(folder);
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
 
   return jsonResponse(folderToResponse(folder));
 }
@@ -133,7 +133,7 @@ export async function handleDeleteFolder(request: Request, env: Env, userId: str
   await storage.clearFolderFromCiphers(userId, id);
   await storage.deleteFolder(id, userId);
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
 
   return new Response(null, { status: 204 });
 }
@@ -156,7 +156,7 @@ export async function handleBulkDeleteFolders(request: Request, env: Env, userId
 
   const revisionDate = await storage.bulkDeleteFolders(ids, userId);
   if (revisionDate) {
-    await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+    notifyVaultSyncForRequest(request, env, userId, revisionDate);
   }
 
   return new Response(null, { status: 204 });

--- a/src/handlers/import.ts
+++ b/src/handlers/import.ts
@@ -289,7 +289,7 @@ export async function handleCiphersImport(request: Request, env: Env, userId: st
 
   // Update revision date
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyUserVaultSync(env, userId, revisionDate, readActingDeviceIdentifier(request));
+  notifyUserVaultSync(env, userId, revisionDate, readActingDeviceIdentifier(request));
 
   if (returnCipherMap) {
     return jsonResponse({

--- a/src/handlers/sends-private.ts
+++ b/src/handlers/sends-private.ts
@@ -76,7 +76,7 @@ async function processSendFileUpload(
 
   const storage = new StorageService(env.DB);
   const revisionDate = await storage.updateRevisionDate(send.userId);
-  await notifyVaultSyncForRequest(request, env, send.userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, send.userId, revisionDate);
 
   return new Response(null, { status: 201 });
 }
@@ -226,7 +226,7 @@ export async function handleCreateSend(request: Request, env: Env, userId: strin
 
   await storage.saveSend(send);
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
 
   return jsonResponse(sendToResponse(send));
 }
@@ -349,7 +349,7 @@ export async function handleCreateFileSendV2(request: Request, env: Env, userId:
 
   await storage.saveSend(send);
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
   const jwtSecret = getSafeJwtSecret(env);
   if (!jwtSecret) {
     return errorResponse('Server configuration error', 500);
@@ -596,7 +596,7 @@ export async function handleUpdateSend(request: Request, env: Env, userId: strin
   send.updatedAt = new Date().toISOString();
   await storage.saveSend(send);
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
 
   return jsonResponse(sendToResponse(send));
 }
@@ -619,7 +619,7 @@ export async function handleDeleteSend(request: Request, env: Env, userId: strin
 
   await storage.deleteSend(sendId, userId);
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
 
   return new Response(null, { status: 200 });
 }
@@ -650,7 +650,7 @@ export async function handleBulkDeleteSends(request: Request, env: Env, userId: 
 
   const revisionDate = await storage.bulkDeleteSends(body.ids, userId);
   if (revisionDate) {
-    await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+    notifyVaultSyncForRequest(request, env, userId, revisionDate);
   }
 
   return new Response(null, { status: 200 });
@@ -668,7 +668,7 @@ export async function handleRemoveSendPassword(request: Request, env: Env, userI
   send.updatedAt = new Date().toISOString();
   await storage.saveSend(send);
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
 
   return jsonResponse(sendToResponse(send));
 }
@@ -686,7 +686,7 @@ export async function handleRemoveSendAuth(request: Request, env: Env, userId: s
   send.updatedAt = new Date().toISOString();
   await storage.saveSend(send);
   const revisionDate = await storage.updateRevisionDate(userId);
-  await notifyVaultSyncForRequest(request, env, userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
 
   return jsonResponse(sendToResponse(send));
 }

--- a/src/handlers/sends-public.ts
+++ b/src/handlers/sends-public.ts
@@ -89,7 +89,7 @@ export async function handleAccessSend(request: Request, env: Env, accessId: str
     }
     send.accessCount += 1;
     const revisionDate = await storage.updateRevisionDate(send.userId);
-    await notifyVaultSyncForRequest(request, env, send.userId, revisionDate);
+    notifyVaultSyncForRequest(request, env, send.userId, revisionDate);
   }
 
   const creatorIdentifier = await getCreatorIdentifier(storage, send);
@@ -162,7 +162,7 @@ export async function handleAccessSendFile(
   }
   send.accessCount += 1;
   const revisionDate = await storage.updateRevisionDate(send.userId);
-  await notifyVaultSyncForRequest(request, env, send.userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, send.userId, revisionDate);
 
   const token = await createSendFileDownloadToken(send.id, fileId, secret);
   const url = new URL(request.url);
@@ -202,7 +202,7 @@ export async function handleAccessSendV2(request: Request, env: Env): Promise<Re
     }
     send.accessCount += 1;
     const revisionDate = await storage.updateRevisionDate(send.userId);
-    await notifyVaultSyncForRequest(request, env, send.userId, revisionDate);
+    notifyVaultSyncForRequest(request, env, send.userId, revisionDate);
   }
 
   const creatorIdentifier = await getCreatorIdentifier(storage, send);
@@ -241,7 +241,7 @@ export async function handleAccessSendFileV2(request: Request, env: Env, fileId:
   }
   send.accessCount += 1;
   const revisionDate = await storage.updateRevisionDate(send.userId);
-  await notifyVaultSyncForRequest(request, env, send.userId, revisionDate);
+  notifyVaultSyncForRequest(request, env, send.userId, revisionDate);
 
   const downloadToken = await createSendFileDownloadToken(send.id, fileId, jwt.secret);
   const url = new URL(request.url);

--- a/src/handlers/sends-shared.ts
+++ b/src/handlers/sends-shared.ts
@@ -9,13 +9,13 @@ export const SEND_INACCESSIBLE_MSG = 'Send does not exist or is no longer availa
 const SEND_PASSWORD_ITERATIONS = 100_000;
 export const SEND_PASSWORD_LIMIT_SCOPE = 'send-password';
 
-export async function notifyVaultSyncForRequest(
+export function notifyVaultSyncForRequest(
   request: Request,
   env: Env,
   userId: string,
   revisionDate: string
-): Promise<void> {
-  await notifyUserVaultSync(env, userId, revisionDate, readActingDeviceIdentifier(request));
+): void {
+  notifyUserVaultSync(env, userId, revisionDate, readActingDeviceIdentifier(request));
 }
 
 export function getAliasedProp(source: unknown, aliases: string[]): { present: boolean; value: unknown } {


### PR DESCRIPTION
### 背景

目前所有写操作 API（如创建/更新 cipher、folder、send、attachment、设备删除等）在完成数据写入后，会 `await` 通知推送至 Durable Object 的 fetch 调用，等待 WebSocket 消息广播完毕后才返回 HTTP 响应。

实际上，通知推送属于"响应后的辅助工作"：客户端并不依赖通知推送的结果来判断写操作是否成功。阻塞等待通知发送完毕只是白白增加了响应延迟。

**关联issue**: #204 

### 方案

利用 Cloudflare Workers 的 [`waitUntil` API](https://developers.cloudflare.com/workers/best-practices/workers-best-practices/#use-waituntil-for-work-after-the-response)，将通知推送改为不阻塞响应返回的后台任务：

- 从 `cloudflare:workers` 导入 `waitUntil`，无需传递 `ctx` 执行上下文
- `waitUntil` 会延长 Worker 执行生命周期，通知推送的 Promise 在响应发送后仍能完成
- 通知推送失败不会影响 API 响应（原有 try-catch 错误处理仍保留在 `notifyUserUpdate` 内部）

### 改动范围

#### 核心改动 — `src/durable/notifications-hub.ts`

- 从 `cloudflare:workers` 导入 `waitUntil`
- `notifyUserVaultSync`：从 `async function → Promise<void>` 改为同步 `function → void`，内部用 `waitUntil()` 包裹通知调用
- `notifyUserLogout`：同上
- `notifyUserUpdate`（私有）：保持 `async` 不变，返回的 Promise 交给 `waitUntil` 追踪

#### 调用处改动 — 移除 `await`

| 文件 | 改动说明 |
|------|----------|
| `src/handlers/ciphers.ts` | `notifyVaultSyncForRequest` 去 `async`/`await`，15 处调用移除 `await` |
| `src/handlers/folders.ts` | `notifyVaultSyncForRequest` 去 `async`/`await`，4 处调用移除 `await` |
| `src/handlers/attachments.ts` | `notifyVaultSyncForRequest` 去 `async`/`await`，4 处调用移除 `await` |
| `src/handlers/sends-shared.ts` | `notifyVaultSyncForRequest`（export）去 `async`/`await` |
| `src/handlers/sends-private.ts` | 8 处调用移除 `await` |
| `src/handlers/sends-public.ts` | 4 处调用移除 `await` |
| `src/handlers/import.ts` | 1 处直接调用移除 `await` |
| `src/handlers/devices.ts` | 3 处 `notifyUserLogout` 调用移除 `await` |

#### 未改动

- `notifyUserBackupProgress` / `notifyUserBackupRestoreProgress` — 备份进度通知保持 `await` 不变，因为暂不清楚其是否依赖严格顺序控制

### 效果

- 写操作 API 的响应延迟降低（省去了一次 Worker 到 Durable Object 的 fetch 往返等待）
- 通知推送仍能完成（由 `waitUntil` 保证 Worker 执行生命周期延长）
- 通知推送失败不影响 API 正常响应（fire-and-forget 语义）
