### PR TITLE
fix(deploy): make deploy:kv idempotent — auto-resolve the KV namespace id

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "i18n": "node scripts/i18n-validate.cjs",
     "i18n:validate": "node scripts/i18n-validate.cjs",
     "deploy": "npm run build && wrangler deploy",
-    "deploy:kv": "npm run build && wrangler deploy -c wrangler.kv.toml",
+    "deploy:kv": "node scripts/ensure-kv.cjs && npm run build && wrangler deploy -c wrangler.kv.toml",
     "deploy:demo": "npm run build:demo && wrangler pages deploy dist --project-name nw-demo"
   },
   "keywords": [

--- a/scripts/ensure-kv.cjs
+++ b/scripts/ensure-kv.cjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * ensure-kv.cjs — make `deploy:kv` idempotent across repeated builds.
+ *
+ * KV namespaces are referenced in wrangler config by their account-scoped `id`,
+ * not by name. The template ships `wrangler.kv.toml` without an id so that a
+ * fresh account can auto-provision one on first deploy. However, wrangler's
+ * non-interactive provisioning only ever *creates* a namespace, so every build
+ * after the first fails with:
+ *
+ *   ✘ a namespace with this account ID and title already exists [code: 10014]
+ *
+ * This script runs before `wrangler deploy` and pins a valid id:
+ *   - if the config already has an id, it does nothing (respects manual pins);
+ *   - otherwise it reuses the existing namespace (matched by title),
+ *   - or creates it once, then injects the id into wrangler.kv.toml for this
+ *     build. In CI the working tree is ephemeral, so nothing gets committed.
+ */
+const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const CONFIG = path.resolve(__dirname, '..', 'wrangler.kv.toml');
+const BINDING = 'ATTACHMENTS_KV';
+
+const wrangler = (args) =>
+  execSync(`npx wrangler ${args}`, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'] });
+
+/** Find the [[kv_namespaces]] block for BINDING and report whether it has an id. */
+function bindingBlockHasId(toml) {
+  const blocks = toml.match(/\[\[kv_namespaces\]\][^[]*/g) || [];
+  const block = blocks.find((b) => new RegExp(`binding\\s*=\\s*"${BINDING}"`).test(b));
+  return block ? /^\s*id\s*=/m.test(block) : false;
+}
+
+/** Expected namespace title, mirroring wrangler's auto-provision naming. */
+function expectedTitle(toml) {
+  const name = (toml.match(/^\s*name\s*=\s*"([^"]+)"/m) || [])[1] || 'worker';
+  return `${name}-${BINDING.toLowerCase().replace(/_/g, '-')}`;
+}
+
+function resolveId(title) {
+  const list = JSON.parse(wrangler('kv namespace list'));
+  const hit =
+    list.find((n) => n.title === title) ||
+    list.find((n) => typeof n.title === 'string' && n.title.endsWith('attachments-kv'));
+  if (hit) {
+    console.log(`[ensure-kv] reusing existing namespace "${hit.title}" (${hit.id})`);
+    return hit.id;
+  }
+  const out = wrangler(`kv namespace create "${title}"`);
+  const id = (out.match(/id\s*=\s*"([0-9a-fA-F]{32})"/) || [])[1];
+  if (!id) throw new Error(`[ensure-kv] could not parse new namespace id from:\n${out}`);
+  console.log(`[ensure-kv] created namespace "${title}" (${id})`);
+  return id;
+}
+
+function main() {
+  let toml = fs.readFileSync(CONFIG, 'utf8');
+  if (bindingBlockHasId(toml)) {
+    console.log(`[ensure-kv] ${BINDING} already pinned in wrangler.kv.toml — nothing to do`);
+    return;
+  }
+  const id = resolveId(expectedTitle(toml));
+  toml = toml.replace(
+    new RegExp(`(\\[\\[kv_namespaces\\]\\]\\s*\\n\\s*binding\\s*=\\s*"${BINDING}")`),
+    `$1\nid = "${id}"`,
+  );
+  fs.writeFileSync(CONFIG, toml);
+  console.log('[ensure-kv] pinned id into wrangler.kv.toml for this build');
+}
+
+main();


### PR DESCRIPTION
## Summary

`npm run deploy:kv` works on the **first** deploy but **fails on every
subsequent build** with:

    a namespace with this account ID and title already exists [code: 10014]

The KV binding ships without an `id`, so wrangler auto-provisions one. In
non-interactive (CI) builds its only fallback is to *create* a namespace, so the
2nd+ build collides with the one the 1st build created. This bites anyone using
the README's recommended Cloudflare Git-integration flow: build #1 passes, every
build after fails.

The wiki already documents a **manual** workaround (create the namespace, paste
its `id` into `wrangler.kv.toml`). This PR **automates** it, which matters for
two reasons:

1. **Zero manual config** — forkers no longer paste an account-specific id by hand.
2. **Survives upstream sync** — the fix lives in code, not a per-fork config edit,
   so once merged it reaches every fork through normal syncing. A manually pinned
   id is instead wiped whenever a fork hard-resets to upstream, silently breaking
   deploys again.

## What it does

Adds `scripts/ensure-kv.cjs`, run before the build in `deploy:kv`:

- if the binding already has an `id`, do nothing (respects manual pins);
- otherwise reuse the existing namespace (matched by title) or create it once,
  then inject the id into `wrangler.kv.toml` for that build.

CI working trees are ephemeral, so nothing is committed; local runs leave the id
as an uncommitted change you can keep or drop. No new dependencies.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Compatibility update
- [ ] Documentation
- [ ] Refactor

## Cross-File Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] Schema changes, if any, updated both runtime schema and `migrations/0001_init.sql`.
- [x] Persistent data changes, if any, updated backup export/import or documented why backup is not needed.
- [x] User-facing text changes, if any, updated all locale files.
- [x] Bitwarden client compatibility was considered for sync/API shape changes.
- [x] No secrets, tokens, private deployment values, or real vault data are included.

## Checks

- [x] `npx tsc -p tsconfig.json --noEmit`
- [x] `npx tsc -p webapp/tsconfig.json --noEmit`
- [x] `npm run i18n:validate`
- [x] `npm run build`

## Notes

Pure build-tooling change — only `package.json` (the `deploy:kv` script) and the
new `scripts/ensure-kv.cjs`. No runtime/app code, schema, or API surface is
touched. Related: the "KV 部署时报绑定 ID 不存在" wiki FAQ — this automates that
manual step.
