### PR TITLE
fix: prevent vault items' last edited time from updating to recent login time after login

### DIFF
--- a/src/handlers/attachments.ts
+++ b/src/handlers/attachments.ts
@@ -345,10 +345,12 @@ export async function handleUpdateAttachmentMetadata(
   }
 
   await storage.saveAttachment(attachment);
-  const revisionInfo = await storage.updateCipherRevisionDate(cipherId);
-  if (revisionInfo) {
-    notifyVaultSyncForRequest(request, env, revisionInfo.userId, revisionInfo.revisionDate);
-  }
+  // Attachment metadata repair is a compatibility maintenance operation
+  // (like URI checksum repair / cipher key mismatch repair) — it must NOT
+  // update the cipher's "last edited" timestamp.  Only bump the user-level
+  // revision date so that clients pull the corrected attachment metadata.
+  const revisionDate = await storage.updateRevisionDate(userId);
+  notifyVaultSyncForRequest(request, env, userId, revisionDate);
 
   return jsonResponse({
     object: 'attachment',

--- a/src/handlers/ciphers.ts
+++ b/src/handlers/ciphers.ts
@@ -823,6 +823,7 @@ export async function handleUpdateCipher(request: Request, env: Env, userId: str
   const incomingPasswordHistory = readCipherProp<PasswordHistory[] | null>(cipherData, ['passwordHistory', 'PasswordHistory']);
   const incomingRevisionDate = readCipherRevisionDate(cipherData);
   const hasAttachmentMigrationMetadata = hasIncomingAttachmentMetadata(cipherData);
+  const preserveRevisionDate = !!body.preserveRevisionDate;
 
   if (incomingKey.present && !shouldAcceptCipherKey(incomingKey.value)) {
     return errorResponse('Cipher key encryption is not supported by this server. Resync the client and try again.', 400);
@@ -840,9 +841,11 @@ export async function handleUpdateCipher(request: Request, env: Env, userId: str
 
   // Opaque passthrough: merge existing stored data with ALL incoming client fields.
   // Unknown/future fields from the client are preserved; server-controlled fields are protected.
+  // Remove preserveRevisionDate before merge so it never leaks into stored data.
+  const { preserveRevisionDate: _preserveRevisionDate, ...cipherDataWithoutFlags } = cipherData;
   const cipher: Cipher = {
     ...existingCipher,   // start with all existing stored data (including unknowns)
-    ...cipherData,       // overlay all client data (including new/unknown fields)
+    ...cipherDataWithoutFlags, // overlay all client data (including new/unknown fields)
     // Server-controlled fields (never from client)
     id: existingCipher.id,
     userId: existingCipher.userId,
@@ -850,7 +853,7 @@ export async function handleUpdateCipher(request: Request, env: Env, userId: str
     favorite: cipherData.favorite ?? existingCipher.favorite,
     reprompt: cipherData.reprompt ?? existingCipher.reprompt,
     createdAt: existingCipher.createdAt,
-    updatedAt: new Date().toISOString(),
+    updatedAt: preserveRevisionDate ? existingCipher.updatedAt : new Date().toISOString(),
     archivedAt: readCipherArchivedAt(cipherData, existingCipher.archivedAt ?? null),
     deletedAt: existingCipher.deletedAt,
   };

--- a/webapp/src/lib/api/vault.ts
+++ b/webapp/src/lib/api/vault.ts
@@ -927,6 +927,7 @@ export async function repairCipherUriChecksums(
         ? cipher.fields.map(({ decName: _decName, decValue: _decValue, ...field }) => field)
         : null,
       lastKnownRevisionDate: cipher.revisionDate ?? null,
+      preserveRevisionDate: true,
     };
     if (keys.key) payload.key = keys.key;
 
@@ -1091,7 +1092,9 @@ export async function repairCipherKeyMismatches(
     if (!cipher?.id || !looksLikeCipherString(cipher.key)) continue;
     if (!(await hasItemKeyFieldMismatch(cipher, userEnc, userMac))) continue;
     if (hasUnresolvedEncryptedFields(cipher)) continue;
-    await updateCipher(authedFetch, session, cipher, draftFromDecryptedCipher(cipher));
+    await updateCipher(authedFetch, session, cipher, draftFromDecryptedCipher(cipher), {
+      preserveRevisionDate: true,
+    });
     repaired += 1;
   }
 
@@ -1225,9 +1228,13 @@ export async function updateCipher(
   authedFetch: AuthedFetch,
   session: SessionState,
   cipher: Cipher,
-  draft: VaultDraft
+  draft: VaultDraft,
+  extraPayload?: Record<string, unknown>
 ): Promise<Cipher> {
   const payload = await buildCipherPayload(session, draft, cipher);
+  if (extraPayload) {
+    Object.assign(payload, extraPayload);
+  }
 
   const resp = await authedFetch(`/api/ciphers/${encodeURIComponent(cipher.id)}`, {
     method: 'PUT',


### PR DESCRIPTION
Fixes #246。

**问题**

登录后，密码库所有条目的"最后编辑时间"（updatedAt / RevisionDate）都被错误地更新为最近登录时间。

**根因**

有三条路径会在用户没有主动编辑的情况下，不正确地更新密码库条目的"最后编辑时间"（`updatedAt`）：

1. **`repairCipherUriChecksums`** — 登录后自动修复不完整的 URI checksum，把 `handleUpdateCipher` 的 `updatedAt` 刷成了当前时间。
2. **`repairCipherKeyMismatches`** — 登录后自动修复不兼容的 cipher key 格式，同样触发 `handleUpdateCipher` 刷时间。
3. **`handleUpdateAttachmentMetadata`** — 附件元数据修复（兼容性维护操作：用户下载一个通过旧加密方案加密的附件时）调用了 `updateCipherRevisionDate(cipherId)`，直接更新了 cipher 的 `updatedAt`。

这三条路径都不是用户的主动编辑，但服务端没有区分"用户编辑"和"内部自动修复"，导致登录后所有相关条目的 `updatedAt` 都被错误刷新。

**3处改动**

1. **`src/handlers/ciphers.ts`** — 新增 `preserveRevisionDate` 标志位。请求携带此标志时，`updatedAt` 保持原值，否则正常更新为当前时间；标志位在数据合并前剥离，不会写入存储。

2. **`webapp/src/lib/api/vault.ts`** — `repairCipherUriChecksums` 和 `repairCipherKeyMismatches` 在调用 `updateCipher` 时传入 `preserveRevisionDate: true`；`updateCipher` 新增 `extraPayload` 参数支持注入额外字段。用户正常编辑不传该参数，`updatedAt` 照常更新。

3. **`src/handlers/attachments.ts`** — `handleUpdateAttachmentMetadata` 从 `storage.updateCipherRevisionDate(cipherId)`（会更新 cipher 的 `updatedAt`）改为 `storage.updateRevisionDate(userId)`（只触发同步通知，不碰 cipher 时间戳）。