### PR TITLE
fix: use decrypted password histories when duplicate handling

### DIFF
--- a/webapp/src/components/vault/vault-page-helpers.tsx
+++ b/webapp/src/components/vault/vault-page-helpers.tsx
@@ -326,7 +326,7 @@ export function buildCipherDuplicateSignature(cipher: Cipher): string {
       linkedId: field.linkedId ?? null,
     })),
     passwordHistory: (cipher.passwordHistory || []).map((entry) => ({
-      password: valueOrFallback(entry.password),
+      password: valueOrFallback(entry.decPassword ?? entry.password),
       lastUsedDate: valueOrFallback(entry.lastUsedDate),
     })),
   };


### PR DESCRIPTION
## Summary

当前比较重复项目时，会因为用于比较的密码历史记录未使用解密后的密码，导致无法比较出相关重复项，遂修复。

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Compatibility update
- [ ] Documentation
- [ ] Refactor

## Cross-File Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] Schema changes, if any, updated both runtime schema and `migrations/0001_init.sql`.
- [x] Persistent data changes, if any, updated backup export/import or documented why backup is not needed.
- [x] User-facing text changes, if any, updated all locale files.
- [x] Bitwarden client compatibility was considered for sync/API shape changes.
- [x] No secrets, tokens, private deployment values, or real vault data are included.

## Checks

- [x] `npx tsc -p tsconfig.json --noEmit`
- [x] `npx tsc -p webapp/tsconfig.json --noEmit`
- [x] `npm run i18n:validate`
- [x] `npm run build`

## Notes

<!-- Anything reviewers should pay special attention to? -->
