### PR TITLE
Fix CSV export and dialog dismissal / 修复 CSV 导出和弹窗关闭行为

### DIFF
--- a/webapp/src/components/ConfirmDialog.tsx
+++ b/webapp/src/components/ConfirmDialog.tsx
@@ -83,6 +83,7 @@ export default function ConfirmDialog(props: ConfirmDialogProps) {
   const [present, setPresent] = useState(props.open);
   const [closing, setClosing] = useState(false);
   const cardRef = useRef<HTMLFormElement | null>(null);
+  const maskPointerStartedRef = useRef(false);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
   const dialogId = useMemo(() => `confirm-dialog-${++dialogIdCounter}`, []);
   const titleId = `${dialogId}-title`;
@@ -176,8 +177,11 @@ export default function ConfirmDialog(props: ConfirmDialogProps) {
   return createPortal((
     <div
       className={`dialog-mask ${props.variant === 'warning' ? 'warning' : ''} ${props.open && !closing ? 'open' : ''} ${closing ? 'closing' : ''}`}
+      onPointerDown={(event) => {
+        maskPointerStartedRef.current = event.target === event.currentTarget;
+      }}
       onClick={(event) => {
-        if (event.target !== event.currentTarget || !canDismiss) return;
+        if (event.target !== event.currentTarget || !maskPointerStartedRef.current || !canDismiss) return;
         props.onCancel();
       }}
     >

--- a/webapp/src/hooks/useVaultSendActions.ts
+++ b/webapp/src/hooks/useVaultSendActions.ts
@@ -4,6 +4,7 @@ import type { ExportRequest, ZipAttachmentEntry } from '@/lib/export-formats';
 import {
   attachNodeWardenEncryptedAttachmentPayload,
   buildAccountEncryptedBitwardenJsonString,
+  buildBitwardenCsvString,
   buildBitwardenZipBytes,
   buildExportFileName,
   buildNodeWardenAttachmentRecords,
@@ -1189,6 +1190,12 @@ export default function useVaultSendActions(options: UseVaultSendActionsOptions)
             fileName: buildExportFileName(format),
             mimeType: 'application/json',
             bytes: new TextEncoder().encode(await getPlainJson()),
+          };
+        } else if (format === 'bitwarden_csv') {
+          result = {
+            fileName: buildExportFileName(format),
+            mimeType: 'text/csv;charset=utf-8',
+            bytes: new TextEncoder().encode(buildBitwardenCsvString(await getPlainJsonDoc())),
           };
         } else if (format === 'bitwarden_encrypted_json') {
           if (request.encryptedJsonMode === 'password') {

--- a/webapp/src/lib/export-formats.ts
+++ b/webapp/src/lib/export-formats.ts
@@ -9,6 +9,7 @@ configureZipJs({ useWebWorkers: false });
 
 export const EXPORT_FORMATS = [
   { id: 'bitwarden_json', label: 'Bitwarden (vault as json)' },
+  { id: 'bitwarden_csv', label: 'Bitwarden (vault as csv)' },
   { id: 'bitwarden_encrypted_json', label: 'Bitwarden (encrypted vault as json)' },
   { id: 'bitwarden_json_zip', label: 'Bitwarden (vault + attachments as zip)' },
   { id: 'bitwarden_encrypted_json_zip', label: 'Bitwarden (encrypted vault + attachments as zip)' },
@@ -68,6 +69,27 @@ interface PasswordProtectedArgs {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object';
+}
+
+function csvText(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function escapeCsvCell(value: unknown): string {
+  const text = csvText(value);
+  if (!/[",\r\n]/.test(text)) return text;
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+function buildCsvString(rows: string[][]): string {
+  return `${rows.map((row) => row.map(escapeCsvCell).join(',')).join('\r\n')}\r\n`;
 }
 
 function isCipherString(value: string): boolean {
@@ -383,6 +405,107 @@ export async function buildPlainBitwardenJsonString(args: BuildPlainJsonArgs): P
   return JSON.stringify(doc, null, 2);
 }
 
+const BITWARDEN_CSV_HEADERS = [
+  'folder',
+  'favorite',
+  'type',
+  'name',
+  'notes',
+  'fields',
+  'reprompt',
+  'login_uri',
+  'login_username',
+  'login_password',
+  'login_totp',
+] as const;
+
+function bitwardenCsvType(type: number): 'login' | 'note' {
+  return type === 1 ? 'login' : 'note';
+}
+
+function sourceTypeLabel(type: number): string {
+  if (type === 3) return 'card';
+  if (type === 4) return 'identity';
+  if (type === 5) return 'sshKey';
+  if (type === 2) return 'note';
+  return `type ${type}`;
+}
+
+function appendFieldLine(lines: string[], name: unknown, value: unknown): void {
+  const key = csvText(name).trim();
+  const text = csvText(value);
+  if (!key || !text) return;
+  lines.push(`${key}: ${text}`);
+}
+
+function appendRecordFieldLines(lines: string[], prefix: string, value: unknown): void {
+  if (!isRecord(value)) return;
+  for (const [key, fieldValue] of Object.entries(value)) {
+    appendFieldLine(lines, `${prefix}.${key}`, fieldValue);
+  }
+}
+
+function buildBitwardenCsvFields(item: Record<string, unknown>, type: number): string {
+  const lines: string[] = [];
+  const fields = Array.isArray(item.fields) ? item.fields : [];
+  for (const field of fields) {
+    if (!isRecord(field)) continue;
+    appendFieldLine(lines, field.name, field.value);
+  }
+  if (type !== 1 && type !== 2) {
+    appendFieldLine(lines, 'nodewardenType', sourceTypeLabel(type));
+    appendRecordFieldLines(lines, sourceTypeLabel(type), item[sourceTypeLabel(type)]);
+  }
+  return lines.join('\n');
+}
+
+function buildFolderNameById(foldersRaw: unknown): Map<string, string> {
+  const out = new Map<string, string>();
+  const folders = Array.isArray(foldersRaw) ? foldersRaw : [];
+  for (const folder of folders) {
+    if (!isRecord(folder)) continue;
+    const id = csvText(folder.id).trim();
+    if (!id) continue;
+    out.set(id, csvText(folder.name));
+  }
+  return out;
+}
+
+function buildBitwardenCsvLoginUri(login: Record<string, unknown> | null): string {
+  const uris = Array.isArray(login?.uris) ? login.uris : [];
+  return uris
+    .map((uri) => (isRecord(uri) ? csvText(uri.uri).trim() : ''))
+    .filter(Boolean)
+    .join('\n');
+}
+
+export function buildBitwardenCsvString(bitwardenJsonDoc: Record<string, unknown>): string {
+  const folderNameById = buildFolderNameById(bitwardenJsonDoc.folders);
+  const rows: string[][] = [[...BITWARDEN_CSV_HEADERS]];
+  const items = Array.isArray(bitwardenJsonDoc.items) ? bitwardenJsonDoc.items : [];
+  for (const itemRaw of items) {
+    if (!isRecord(itemRaw)) continue;
+    const type = normalizeNumber(itemRaw.type, 1);
+    const isLogin = type === 1;
+    const login = isRecord(itemRaw.login) ? itemRaw.login : null;
+    const folderId = csvText(itemRaw.folderId).trim();
+    rows.push([
+      folderNameById.get(folderId) || '',
+      itemRaw.favorite ? '1' : '0',
+      bitwardenCsvType(type),
+      csvText(itemRaw.name) || '--',
+      csvText(itemRaw.notes),
+      buildBitwardenCsvFields(itemRaw, type),
+      String(normalizeNumber(itemRaw.reprompt, 0)),
+      isLogin ? buildBitwardenCsvLoginUri(login) : '',
+      isLogin ? csvText(login?.username) : '',
+      isLogin ? csvText(login?.password) : '',
+      isLogin ? csvText(login?.totp) : '',
+    ]);
+  }
+  return `\uFEFF${buildCsvString(rows)}`;
+}
+
 export async function buildAccountEncryptedBitwardenJsonString(args: BuildEncryptedJsonArgs): Promise<string> {
   const userEnc = base64ToBytes(args.userEncB64);
   const userMac = base64ToBytes(args.userMacB64);
@@ -566,11 +689,13 @@ function nowStamp(now = new Date()): string {
 export function buildExportFileName(format: ExportFormatId, zipEncrypted = false): string {
   const stamp = nowStamp();
   if (
+    format === 'bitwarden_csv' ||
     format === 'bitwarden_json' ||
     format === 'bitwarden_encrypted_json' ||
     format === 'nodewarden_json' ||
     format === 'nodewarden_encrypted_json'
   ) {
+    if (format === 'bitwarden_csv') return `bitwarden_export_${stamp}.csv`;
     if (format.startsWith('nodewarden_')) return `nodewarden_export_${stamp}.json`;
     return `bitwarden_export_${stamp}.json`;
   }

--- a/webapp/src/lib/export-formats.ts
+++ b/webapp/src/lib/export-formats.ts
@@ -92,6 +92,10 @@ function buildCsvString(rows: string[][]): string {
   return `${rows.map((row) => row.map(escapeCsvCell).join(',')).join('\r\n')}\r\n`;
 }
 
+function buildSingleRowCsvString(values: string[]): string {
+  return values.map(escapeCsvCell).join(',');
+}
+
 function isCipherString(value: string): boolean {
   return /^\d+\.[A-Za-z0-9+/=]+\|[A-Za-z0-9+/=]+(?:\|[A-Za-z0-9+/=]+)?$/.test(String(value || '').trim());
 }
@@ -473,10 +477,9 @@ function buildFolderNameById(foldersRaw: unknown): Map<string, string> {
 
 function buildBitwardenCsvLoginUri(login: Record<string, unknown> | null): string {
   const uris = Array.isArray(login?.uris) ? login.uris : [];
-  return uris
+  return buildSingleRowCsvString(uris
     .map((uri) => (isRecord(uri) ? csvText(uri.uri).trim() : ''))
-    .filter(Boolean)
-    .join('\n');
+    .filter(Boolean));
 }
 
 export function buildBitwardenCsvString(bitwardenJsonDoc: Record<string, unknown>): string {


### PR DESCRIPTION
﻿## Summary

Adds a Bitwarden CSV export option directly below the plain Bitwarden JSON export option. The CSV output uses the Bitwarden-compatible vault columns, UTF-8 BOM, and proper escaping for commas, newlines, and quotes.

Wires the new CSV format into the vault export download flow with a `.csv` filename and `text/csv` MIME type.

Updates dialog backdrop dismissal so dragging from inside a dialog/input to outside the dialog no longer closes it accidentally, while direct outside clicks still dismiss the dialog.

## 总结

新增 Bitwarden CSV 导出选项，并将它放在普通 Bitwarden JSON 导出选项下方。CSV 输出使用兼容 Bitwarden 的密码库字段、UTF-8 BOM，并正确转义逗号、换行和双引号。

将新的 CSV 格式接入密码库导出下载流程，生成 `.csv` 文件并使用 `text/csv` MIME 类型。

调整弹窗遮罩关闭逻辑：从弹窗或输入框内部拖动到弹窗外松手不会再误关闭弹窗，直接点击弹窗外仍会关闭弹窗。

## Verification

- Ran `npm run build`.
- Verified in the demo web app that `Bitwarden (vault as csv)` appears directly below `Bitwarden (vault as json)` in the export format selector.
- Verified the device note dialog remains open when dragging from the input to outside the dialog, and still closes on a direct backdrop click.
- Smoke-tested the CSV generator for UTF-8 BOM output and escaping of commas, newlines, and quotes.

## 验证

- 已运行 `npm run build`。
- 已在 demo 网页端验证导出格式选择器中 `Bitwarden (vault as csv)` 位于 `Bitwarden (vault as json)` 下方。
- 已验证设备备注弹窗从输入框拖到弹窗外松手不会关闭，直接点击遮罩仍会关闭。
- 已对 CSV 生成函数做冒烟验证，确认会输出 UTF-8 BOM，并正确转义逗号、换行和双引号。
