### PR TITLE
Enable WebAuthn related origins support

### DIFF
--- a/src/router-public.ts
+++ b/src/router-public.ts
@@ -127,6 +127,7 @@ function buildConfigResponse(origin: string) {
       'email-verification': true,
       'pm-19051-send-email-verification': false,
       'pm-19148-innovation-archive': true,
+      'pm-30529-webauthn-related-origins': true,
       'unauth-ui-refresh': true,
       'web-push': false,
     },
@@ -469,7 +470,7 @@ export async function handlePublicRoute(
     const blocked = await enforcePublicRateLimit('public-read', LIMITS.rateLimit.publicReadRequestsPerMinute);
     if (blocked) return blocked;
     const origin = new URL(request.url).origin;
-    return jsonResponse(buildConfigResponse(origin));
+    return jsonResponse(buildConfigResponse(origin), 200, { 'Cache-Control': 'no-store' });
   }
 
   if (path === '/api/version' && method === 'GET') {


### PR DESCRIPTION
Fixes passkey creation for Facebook/Meta in Bitwarden clients.

Facebook uses origin `accountscenter.facebook.com` while the WebAuthn RP ID is `accounts.meta.com`. Recent Bitwarden clients support WebAuthn Related Origin Requests behind the `pm-30529-webauthn-related-origins` feature flag.

This change enables that feature flag in `/api/config` and marks config responses as `no-store` so clients do not keep stale feature state.

Verified with a self-hosted NodeWarden deployment: after refreshing the Bitwarden extension config, Facebook/Meta passkey creation succeeds.