### PR TITLE
fix: preserve multiline values (e.g. SSH private keys) during CSV import

### DIFF
--- a/webapp/src/lib/import-formats-browser.ts
+++ b/webapp/src/lib/import-formats-browser.ts
@@ -42,19 +42,31 @@ const NODEWARDEN_CSV_OBJECT_FIELDS: Record<'card' | 'identity' | 'sshKey', reado
   sshKey: ['privateKey', 'publicKey', 'keyFingerprint', 'fingerprint'],
 };
 
+// Parse the `fields` CSV column into key-value pairs.
+// Lines without a `: ` delimiter are treated as continuations of the previous
+// line's value, preserving multiline content such as SSH private keys.
 function parseBitwardenCsvFieldLines(rawFields: unknown): BitwardenCsvFieldLine[] {
   return String(rawFields || '')
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean)
-    .map((line) => {
+    .reduce<BitwardenCsvFieldLine[]>((acc, line) => {
       const delim = line.lastIndexOf(': ');
-      if (delim < 0) return null;
+      if (delim < 0) {
+        // Continuation line — append to the previous entry's value.
+        if (acc.length > 0) {
+          acc[acc.length - 1].value += '\n' + line;
+        }
+        return acc;
+      }
+      // New key-value line.
       const key = txt(line.slice(0, delim));
       const value = txt(line.slice(delim + 2));
-      return key && value ? { key, value } : null;
-    })
-    .filter((line): line is BitwardenCsvFieldLine => !!line);
+      if (key && value) {
+        acc.push({ key, value });
+      }
+      return acc;
+    }, []);
 }
 
 function getNodeWardenCsvType(lines: BitwardenCsvFieldLine[]): number | null {


### PR DESCRIPTION
## Summary

`parseBitwardenCsvFieldLines` previously discarded any field line that did not contain the `': '` delimiter, truncating multiline values like OpenSSH private keys to only their first line.

Replace the `map`+`filter` pipeline with a `reduce` that accumulates continuation lines (lines without `': '`) into the previous entry's value, joined by `'\n'`. This preserves the full private key content through a CSV round-trip.

Fixes: CSV export → import of SSH key items where the private key body was silently dropped.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Compatibility update
- [ ] Documentation
- [ ] Refactor

## Cross-File Checklist

- [x] I read `CONTRIBUTING.md`.
- [ ] Schema changes, if any, updated both runtime schema and `migrations/0001_init.sql`.
- [ ] Persistent data changes, if any, updated backup export/import or documented why backup is not needed.
- [ ] User-facing text changes, if any, updated all locale files.
- [ ] Bitwarden client compatibility was considered for sync/API shape changes.
- [x] No secrets, tokens, private deployment values, or real vault data are included.

## Checks

- [x] `npx tsc -p tsconfig.json --noEmit`
- [x] `npx tsc -p webapp/tsconfig.json --noEmit`
- [x] `npm run i18n:validate`
- [x] `npm run build`


# Bug 复现流程：SSH 私钥 CSV 导入截断

## 前置条件

- 运行中的 NodeWarden 实例
- 一个可用的 SSH 密钥对

## 复现步骤

### 1. 生成测试 SSH 密钥

```bash
ssh-keygen -t ed25519 -f /tmp/test_ssh_key -N "" -C "test@nodewarden"
```

### 2. 在 NodeWarden Web UI 中创建 SSH Key 条目

1. 登录 NodeWarden
2. 点击"新建"→ 选择 **SSH Key**
3. 名称填入：`Test SSH Key`
4. 私钥填入 `/tmp/test_ssh_key` 的内容
5. 公钥填入 `/tmp/test_ssh_key.pub` 的内容
6. 保存

### 3. 导出为 CSV

1. 进入 **导入/导出** 页面
2. 导出格式选择 **Bitwarden CSV**（`bitwarden_csv`）
3. 输入主密码验证
4. 下载 CSV 文件

### 4. 验证导出的 CSV

打开 CSV 文件，找到 `fields` 列。预期看到类似内容（key 和 value 在同一条记录中，用逗号分隔的字段）：

```
sshKey.privateKey: -----BEGIN OPENSSH PRIVATE KEY-----
b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
QyNTUxOQAAACAVbzI5zezE/q/2onjY/LJ/ZtX70JUUXeFZjbPqZBVUoAAAAJjPOwpazzsK
...
-----END OPENSSH PRIVATE KEY-----
```

CSV 中 `fields` 单元格内容被双引号包裹，换行符在引号内保留。

### 5. 删除原条目

回到密码库，删除刚才创建的 `Test SSH Key` 条目。

### 6. 导入 CSV

1. 进入 **导入/导出** 页面
2. 导入格式选择 **Bitwarden CSV**（`bitwarden_csv`）
3. 选择刚才导出的 CSV 文件
4. 点击导入

### 7. 验证导入结果

1. 在密码库中找到导入回来的 `Test SSH Key` 条目
2. 打开并查看私钥字段

## 预期结果（Bug）

私钥字段内容只有：

```
-----BEGIN OPENSSH PRIVATE KEY-----
```

中间的所有 base64 内容以及 `-----END OPENSSH PRIVATE KEY-----` 全部丢失。该密钥无法使用。

## 根因

`webapp/src/lib/import-formats-browser.ts` 中 `parseBitwardenCsvFieldLines` 函数将 `fields` 列按换行符分割后，对每一行使用 `lastIndexOf(': ')` 查找分隔符。不包含 `: ` 的行（私钥的 base64 内容和结束标记）被直接丢弃。

## 修复后结果

私钥字段完整保留所有行：

```
-----BEGIN OPENSSH PRIVATE KEY-----
b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
QyNTUxOQAAACAVbzI5zezE/q/2onjY/LJ/ZtX70JUUXeFZjbPqZBVUoAAAAJjPOwpazzsK
WgAAAAtzc2gtZWQyNTUxOQAAACAVbzI5zezE/q/2onjY/LJ/ZtX70JUUXeFZjbPqZBVUo
AAAAAEBAEelZ9q25SeWPGovFm/XafoeZnedWXasIL7+82yAoMBVvMjnN7MT+r/aieNj8sn
9m1fvQlRRd4VmNs+pkFVSgAAAAD3Rlc3RAbm9kZXdhcmRlbgECAwQFBg==
-----END OPENSSH PRIVATE KEY-----
```

