### PR TITLE
fix: decode uploaded TOTP QR images when BarcodeDetector is unavailable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tanstack/react-query": "^5.101.2",
         "@zip.js/zip.js": "^2.8.26",
         "fflate": "^0.8.3",
+        "jsqr": "1.4.0",
         "lucide-preact": "^1.22.0",
         "preact": "^10.29.3",
         "qrcode-generator": "^2.0.4",
@@ -3441,6 +3442,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "license": "Apache-2.0"
     },
     "node_modules/kleur": {
       "version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@tanstack/react-query": "^5.101.2",
     "@zip.js/zip.js": "^2.8.26",
     "fflate": "^0.8.3",
+    "jsqr": "1.4.0",
     "lucide-preact": "^1.22.0",
     "preact": "^10.29.3",
     "qrcode-generator": "^2.0.4",

--- a/webapp/src/components/vault/VaultEditor.tsx
+++ b/webapp/src/components/vault/VaultEditor.tsx
@@ -181,6 +181,11 @@ export default function VaultEditor(props: VaultEditorProps) {
     canvas.height = height;
     const context = canvas.getContext('2d');
     if (!context) return '';
+    // jsQR ignores alpha and reads RGB directly, so transparent pixels would be
+    // treated as black. Composite over white first so transparent-background QR
+    // exports do not become black-on-black and fail to decode.
+    context.fillStyle = '#ffffff';
+    context.fillRect(0, 0, width, height);
     context.drawImage(source, 0, 0, width, height);
     const imageData = context.getImageData(0, 0, width, height);
     return String(jsQR(imageData.data, width, height)?.data || '').trim();

--- a/webapp/src/components/vault/VaultEditor.tsx
+++ b/webapp/src/components/vault/VaultEditor.tsx
@@ -1,6 +1,7 @@
 import type { RefObject } from 'preact';
 import { createPortal } from 'preact/compat';
 import { ArrowDown, ArrowUp, CheckCheck, Download, Paperclip, Plus, QrCode, RefreshCw, Star, StarOff, Trash2, Upload, X } from 'lucide-preact';
+import jsQR from 'jsqr';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import { useDialogLifecycle } from '@/components/ConfirmDialog';
 import type { Cipher, Folder, VaultDraft, VaultDraftField } from '@/lib/types';
@@ -171,16 +172,33 @@ export default function VaultEditor(props: VaultEditorProps) {
     return new window.BarcodeDetector({ formats: ['qr_code'] });
   };
 
-  const decodeTotpQrImage = async (source: ImageBitmapSource): Promise<boolean> => {
+  const decodeTotpQrCanvas = (source: ImageBitmap | HTMLVideoElement): string => {
+    const width = 'videoWidth' in source ? source.videoWidth : source.width;
+    const height = 'videoHeight' in source ? source.videoHeight : source.height;
+    if (!width || !height) return '';
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext('2d');
+    if (!context) return '';
+    context.drawImage(source, 0, 0, width, height);
+    const imageData = context.getImageData(0, 0, width, height);
+    return String(jsQR(imageData.data, width, height)?.data || '').trim();
+  };
+
+  const decodeTotpQrImage = async (source: ImageBitmap): Promise<boolean> => {
     const detector = createTotpQrDetector();
-    if (!detector) {
-      setTotpQrStatus(t('txt_totp_qr_unsupported'));
-      return false;
+    if (detector) {
+      try {
+        const results = await detector.detect(source);
+        const value = String(results[0]?.rawValue || '').trim();
+        if (value && applyTotpQrValue(value)) return true;
+      } catch {
+        // Fall back to jsQR when the native detector is present but not usable.
+      }
     }
-    const results = await detector.detect(source);
-    const value = String(results[0]?.rawValue || '').trim();
-    if (!value) return false;
-    return applyTotpQrValue(value);
+    const value = decodeTotpQrCanvas(source);
+    return value ? applyTotpQrValue(value) : false;
   };
 
   const handleTotpQrFile = async (file: File | null) => {
@@ -207,13 +225,6 @@ export default function VaultEditor(props: VaultEditorProps) {
     }
     let stopped = false;
     const detector = createTotpQrDetector();
-    if (!detector) {
-      setTotpQrStatus(t('txt_totp_qr_unsupported'));
-      return () => {
-        stopped = true;
-        stopTotpQrScanner();
-      };
-    }
     if (!navigator.mediaDevices?.getUserMedia) {
       setTotpQrStatus(t('txt_totp_qr_camera_unavailable'));
       return () => {
@@ -230,8 +241,16 @@ export default function VaultEditor(props: VaultEditorProps) {
         return;
       }
       try {
-        const results = await detector.detect(video);
-        const value = String(results[0]?.rawValue || '').trim();
+        let value = '';
+        if (detector) {
+          try {
+            const results = await detector.detect(video);
+            value = String(results[0]?.rawValue || '').trim();
+          } catch {
+            // Fall back to jsQR when the native detector is present but not usable.
+          }
+        }
+        if (!value) value = decodeTotpQrCanvas(video);
         if (value && applyTotpQrValue(value)) return;
       } catch {
         // Keep the camera active; transient frame decode failures are common.

--- a/webapp/src/components/vault/VaultEditor.tsx
+++ b/webapp/src/components/vault/VaultEditor.tsx
@@ -229,6 +229,7 @@ export default function VaultEditor(props: VaultEditorProps) {
       return;
     }
     let stopped = false;
+    let lastCanvasScan = 0;
     const detector = createTotpQrDetector();
     if (!navigator.mediaDevices?.getUserMedia) {
       setTotpQrStatus(t('txt_totp_qr_camera_unavailable'));
@@ -255,7 +256,16 @@ export default function VaultEditor(props: VaultEditorProps) {
             // Fall back to jsQR when the native detector is present but not usable.
           }
         }
-        if (!value) value = decodeTotpQrCanvas(video);
+        // The jsQR fallback runs a synchronous full-frame decode, so throttle
+        // it to a few times per second instead of every animation frame to
+        // avoid pegging the CPU while a code is being aligned.
+        if (!value) {
+          const now = performance.now();
+          if (now - lastCanvasScan >= 250) {
+            lastCanvasScan = now;
+            value = decodeTotpQrCanvas(video);
+          }
+        }
         if (value && applyTotpQrValue(value)) return;
       } catch {
         // Keep the camera active; transient frame decode failures are common.


### PR DESCRIPTION
## Summary

Fixes #276.

Uploading an image that contains a TOTP QR code reported "no QR code found" on desktop Chrome and Edge.
The camera reader on the same browsers showed "unsupported" and left the preview area empty.
Both symptoms trace to a single cause in the vault editor's TOTP QR reader.

That reader decoded QR codes only through the browser's native BarcodeDetector.
On desktop Chrome and Edge for Windows and Linux, that interface exists but has no working backend, so it always returns an empty result.
The upload path therefore fell straight through to the not-found message, and the camera path gave up with the unsupported message before the preview could even render.

This change adds a small, self-contained fallback decoder built on jsQR, a pure-JavaScript QR reader with no further dependencies of its own.
A helper draws the source, whether an uploaded still image or a live camera frame, onto an in-memory canvas and reads the pixels back for jsQR to decode.
The canvas is painted white first, so a QR export with a transparent background is not flattened into black-on-black.

The upload path now tries the native detector first when it works, then falls back to jsQR before deciding an image has no code.
The camera path no longer refuses to start when only the native detector is missing.
It opens the camera whenever the browser can grant one and decodes each frame with jsQR, which also lets the live preview appear.
That per-frame fallback is throttled to a few decodes each second so it does not saturate the CPU while a user lines up a code.

No new user-facing text was introduced, since the existing translation keys already cover every message shown here.
The work stays inside the TOTP reader and does not touch the QR image generator or any other vault behavior.
It adds one runtime dependency, jsqr, which is small and widely used.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Compatibility update
- [ ] Documentation
- [ ] Refactor

## Cross-File Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] Schema changes, if any, updated both runtime schema and `migrations/0001_init.sql`. (No schema changes here.)
- [x] Persistent data changes, if any, updated backup export/import or documented why backup is not needed. (No persistent data changes here.)
- [x] User-facing text changes, if any, updated all locale files. (No new text; existing keys are reused.)
- [x] Bitwarden client compatibility was considered for sync/API shape changes. (No sync or API shape changes here.)
- [x] No secrets, tokens, private deployment values, or real vault data are included.

## Checks

- [x] `npx tsc -p tsconfig.json --noEmit`
- [x] `npx tsc -p webapp/tsconfig.json --noEmit` (see Notes)
- [x] `npm run i18n:validate`
- [x] `npm run build`

## Notes

The webapp type-check surfaces one error in the backup API module that already exists on main and is unrelated to this change.
The files edited here type-check cleanly, and the production build succeeds.

I verified the behavior by hand on a browser without a working native detector.
Uploading a valid TOTP QR image now applies the secret through the fallback instead of reporting not-found.
An image with no code still reports not-found, and a corrupt or non-image file still reports a scan failure.
On a browser where the native detector works, that path still decodes first with no change in behavior.
