### PR TITLE
fix: reject plaintext FIDO2, SSH keys, and password history on import

### DIFF
--- a/src/handlers/ciphers.ts
+++ b/src/handlers/ciphers.ts
@@ -354,6 +354,34 @@ export function validateCipherEncryptedFieldsForCompatibility(cipher: Cipher): s
         if (uri.uriChecksum != null && !optionalEncStringWithin(uri.uriChecksum, 10000)) return 'Login URI checksum must be an encrypted string up to 10000 characters.';
       }
     }
+
+    // Validate FIDO2 credentials — all encrypted-string fields, both required and optional, must be valid.
+    if (Array.isArray(login.fido2Credentials)) {
+      const fido2EncryptedKeys = ['credentialId', 'keyType', 'keyAlgorithm', 'keyCurve', 'keyValue', 'rpId', 'counter', 'discoverable', 'userHandle', 'userName', 'rpName', 'userDisplayName'];
+      for (const cred of login.fido2Credentials) {
+        if (!cred || typeof cred !== 'object') continue;
+        for (const key of fido2EncryptedKeys) {
+          if (cred[key] != null && !isValidEncString(cred[key])) return `FIDO2 credential ${key} must be an encrypted string.`;
+        }
+      }
+    }
+  }
+
+  // Validate SSH key fields — all three must be encrypted strings.
+  const sshKey = cipher.sshKey as any;
+  if (sshKey && typeof sshKey === 'object') {
+    if (sshKey.privateKey != null && !isValidEncString(sshKey.privateKey)) return 'SSH key private key must be an encrypted string.';
+    if (sshKey.publicKey != null && !isValidEncString(sshKey.publicKey)) return 'SSH key public key must be an encrypted string.';
+    const fingerprint = sshKey.keyFingerprint ?? sshKey.fingerprint;
+    if (fingerprint != null && !isValidEncString(fingerprint)) return 'SSH key fingerprint must be an encrypted string.';
+  }
+
+  // Validate password history — each password must be an encrypted string.
+  if (Array.isArray(cipher.passwordHistory)) {
+    for (const entry of cipher.passwordHistory) {
+      if (!entry || typeof entry !== 'object') continue;
+      if (entry.password != null && !isValidEncString(entry.password)) return 'Password history entry must be an encrypted string.';
+    }
   }
 
   return null;


### PR DESCRIPTION
## Summary

  **健壮性优化：补齐 FIDO2、SSH Key、Password History 的导入校验，与已有字段的防御策略对齐。**

  `validateCipherEncryptedFieldsForCompatibility`
  负责在导入时拦截非加密字符串，防止明文数据被静默写入存储。此前该函数已覆盖
  `name`、`notes`、`login.username`、`login.password`、`login.totp`、`login.uri` 及 URI
  列表等字段，但 **FIDO2 凭据**、**SSH 密钥** 和 **密码历史** 三块未被纳入校验，存在防御盲区：

  - 这些字段如果包含明文，导入时不会报错，数据被直接保存
  - 后续同步到 Bitwarden 客户端时会因为预期 EncString 格式而表现异常
  - 与已有的其他字段校验策略不一致，属于防御不一致的缺口

  本次变更为这三个缺失的类别补充了相同的 `isValidEncString` 校验，确保所有 EncString
  类型字段在导入时受到一致的防御。

  **新增校验的字段：**

  | Category | Fields |
  |---|---|
  | FIDO2 credentials (8 required) | `credentialId`, `keyType`, `keyAlgorithm`, `keyCurve`,
  `keyValue`, `rpId`, `counter`, `discoverable` |
  | SSH key (3 fields, with legacy alias) | `privateKey`, `publicKey`, `keyFingerprint` /
  `fingerprint` |
  | Password history | `password` per entry |

  ## Change Type

  - [ ] Bug fix
  - [ ] Feature
  - [ ] Compatibility update
  - [ ] Documentation
  - [x] Refactor

  ## Cross-File Checklist

  - [x] I read `CONTRIBUTING.md`.
  - [ ] Schema changes, if any, updated both runtime schema and `migrations/0001_init.sql`.
  - [ ] Persistent data changes, if any, updated backup export/import or documented why backup is
  not needed.
  - [ ] User-facing text changes, if any, updated all locale files.
  - [x] Bitwarden client compatibility was considered for sync/API shape changes.
  - [x] No secrets, tokens, private deployment values, or real vault data are included.

  ## Checks

  - [x] `npx tsc -p tsconfig.json --noEmit`
  - [x] `npx tsc -p webapp/tsconfig.json --noEmit`
  - [ ] `npm run i18n:validate`
  - [ ] `npm run build`

  ## Notes

  - 校验策略与现有的 `login.username` 等字段一致：仅当字段存在且非 null 时才检查，`null` /
  `undefined` / 缺失字段均通过。
  - SSH Key 的指纹字段同时兼容 `keyFingerprint`（新版格式）和 `fingerprint`（旧版别名），通过
  `sshKey.keyFingerprint ?? sshKey.fingerprint` 取值。
  - FIDO2 凭据数组中 `null` 或非对象的条目会被跳过，与 `uris` 的处理方式保持一致。