### PR TITLE
fix: preserve dialog title during closing animation to prevent flash

### DIFF
--- a/webapp/src/components/ConfirmDialog.tsx
+++ b/webapp/src/components/ConfirmDialog.tsx
@@ -87,6 +87,7 @@ export default function ConfirmDialog(props: ConfirmDialogProps) {
   const cardRef = useRef<HTMLFormElement | null>(null);
   const maskPointerStartedRef = useRef(false);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
+  const lastTitleRef = useRef<ComponentChildren>(props.title);
   const dialogId = useMemo(() => `confirm-dialog-${++dialogIdCounter}`, []);
   const titleId = `${dialogId}-title`;
   const messageId = `${dialogId}-message`;
@@ -95,6 +96,7 @@ export default function ConfirmDialog(props: ConfirmDialogProps) {
 
   useEffect(() => {
     if (props.open) {
+      lastTitleRef.current = props.title;
       setPresent(true);
       setClosing(false);
       return;
@@ -228,7 +230,7 @@ export default function ConfirmDialog(props: ConfirmDialogProps) {
             <X size={18} />
           </button>
         )}
-        <h3 id={titleId} className="dialog-title">{props.title}</h3>
+        <h3 id={titleId} className="dialog-title">{props.open ? props.title : lastTitleRef.current}</h3>
         {hasMessage && <div id={messageId} className={`dialog-message ${props.variant === 'warning' ? 'warning' : ''}`}>{props.message}</div>}
         {props.children}
         {!props.hideConfirm && (


### PR DESCRIPTION
## Summary

  修复 `ConfirmDialog` 关闭动画期间标题闪白/消失的问题。

  当 dialog 开始关闭时，`props.open` 先变为 `false`，但关闭动画仍在播放。此时 `<h3>` 直接渲染`props.title`，若 title 依赖 open 状态或父组件在关闭时清空了props，标题就会瞬间消失或变化，造成视觉闪烁。

  用 `lastTitleRef` 缓存 dialog 打开时的 title，关闭动画期间保持显示缓存的标题，动画完成后 dialog 卸载时自然消失。

  ## Change Type

  - [x] Bug fix
  - [ ] Feature
  - [ ] Compatibility update
  - [ ] Documentation
  - [ ] Refactor

  ## Cross-File Checklist

  - [ ] I read `CONTRIBUTING.md`.
  - [ ] Schema changes, if any, updated both runtime schema and `migrations/0001_init.sql`.
  - [ ] Persistent data changes, if any, updated backup export/import or documented why backup is
  not needed.
  - [ ] User-facing text changes, if any, updated all locale files.
  - [ ] Bitwarden client compatibility was considered for sync/API shape changes.
  - [ ] No secrets, tokens, private deployment values, or real vault data are included.

  ## Checks

  - [ ] `npx tsc -p tsconfig.json --noEmit`
  - [ ] `npx tsc -p webapp/tsconfig.json --noEmit`
  - [ ] `npm run i18n:validate`
  - [ ] `npm run build`

  ## Notes

  仅在 `ConfirmDialog.tsx` 中修改，不影响其他组件或 API。