### PR TITLE
Fix/duplicates group sort

### DIFF
--- a/webapp/src/components/VaultPage.tsx
+++ b/webapp/src/components/VaultPage.tsx
@@ -419,7 +419,36 @@ export default function VaultPage(props: VaultPageProps) {
       return !!meta?.searchText.includes(searchQuery);
     });
 
+    // Pre-compute group min name for duplicates group ordering
+    const groupMinName = new Map<string, string>();
+    if (sidebarFilter.kind === 'duplicates' && duplicateSignatureInfo) {
+      for (const cipher of next) {
+        const gk = (duplicateSignatureInfo.byId.get(cipher.id) || [])
+          .filter(s => (duplicateSignatureInfo.counts.get(s) || 0) >= 2)
+          .sort()[0] || '';
+        if (!gk) continue;
+        const name = cipherMetaById.get(cipher.id)?.name || '';
+        const cur = groupMinName.get(gk);
+        if (!cur || nameCollator.compare(name, cur) < 0) groupMinName.set(gk, name);
+      }
+    }
+
     next.sort((a, b) => {
+      // Duplicates view: group by color, sort A-Z within each group
+      if (sidebarFilter.kind === 'duplicates' && duplicateSignatureInfo) {
+        const gk = (id: string) => (duplicateSignatureInfo.byId.get(id) || [])
+          .filter(s => (duplicateSignatureInfo.counts.get(s) || 0) >= 2)
+          .sort()[0] || '';
+        const gA = gk(a.id), gB = gk(b.id);
+        if (gA !== gB) return !gA ? 1 : !gB ? -1 : nameCollator.compare(
+          groupMinName.get(gA) || '', groupMinName.get(gB) || ''
+        ) || (gA < gB ? -1 : 1);
+        return nameCollator.compare(
+          cipherMetaById.get(a.id)?.name || '',
+          cipherMetaById.get(b.id)?.name || ''
+        ) || String(a.id || '').localeCompare(String(b.id || ''));
+      }
+
       const metaA = cipherMetaById.get(a.id);
       const metaB = cipherMetaById.get(b.id);
       if (sortMode === 'edited') {

--- a/webapp/src/components/VaultPage.tsx
+++ b/webapp/src/components/VaultPage.tsx
@@ -1078,6 +1078,20 @@ const folderName = useCallback((id: string | null | undefined): string => {
     }
     setSelectedMap(map);
   }, [filteredCiphers, duplicateSignatureInfo, duplicateMode]);
+  const handleSelectUniqueFromDuplicates = useCallback(() => {
+    const map: Record<string, boolean> = {};
+    const seen = new Set<number>();
+    for (const cipher of filteredCiphers) {
+      const groupIndex = duplicateGroupIndexById.get(cipher.id);
+      if (groupIndex === undefined) continue;
+      if (seen.has(groupIndex)) {
+        map[cipher.id] = true;
+      } else {
+        seen.add(groupIndex);
+      }
+    }
+    setSelectedMap(map);
+  }, [filteredCiphers, duplicateGroupIndexById]);
   const handleSelectAll = useCallback(() => {
     const map: Record<string, boolean> = {};
     for (const cipher of filteredCiphers) map[cipher.id] = true;
@@ -1192,6 +1206,7 @@ const folderName = useCallback((id: string | null | undefined): string => {
           onSyncVault={handleSyncVault}
           onOpenBulkDelete={handleOpenBulkDelete}
           onSelectDuplicates={handleSelectDuplicates}
+          onSelectUniqueFromDuplicates={handleSelectUniqueFromDuplicates}
           onSelectAll={handleSelectAll}
           onToggleCreateMenu={handleToggleCreateMenu}
           onStartCreate={startCreate}

--- a/webapp/src/components/vault/VaultListPanel.tsx
+++ b/webapp/src/components/vault/VaultListPanel.tsx
@@ -81,6 +81,7 @@ interface VaultListPanelProps {
   onSyncVault: () => void;
   onOpenBulkDelete: () => void;
   onSelectDuplicates: () => void;
+  onSelectUniqueFromDuplicates: () => void;
   onSelectAll: () => void;
   onToggleCreateMenu: () => void;
   onStartCreate: (type: number) => void;
@@ -319,40 +320,43 @@ export default function VaultListPanel(props: VaultListPanelProps) {
             </>
           ) : (
             <>
-              <div className="search-input-wrap">
-                {props.sidebarFilter.kind === 'duplicates' && props.isMobileLayout ? (
-                  <div className="duplicate-mode-head-menu">
+              {props.sidebarFilter.kind === 'duplicates' && props.isMobileLayout ? (
+                <div className="duplicate-mode-head-menu mobile-duplicate-toolbar">
+                  <div className="mobile-duplicate-mode-select-wrap">
                     {renderMobileFilterMenu('duplicate', t('txt_duplicate_detection_mode'), duplicateModeSelected, <Copy size={14} />, duplicateModeOptions)}
                   </div>
-                ) : (
-                  <>
-                    <input
-                      className="search-input"
-                      placeholder={t('txt_search_items_count', { count: props.totalCipherCount })}
-                      value={props.searchInput}
-                      onInput={(e) => props.onSearchInput((e.currentTarget as HTMLInputElement).value)}
-                      onCompositionStart={props.onSearchCompositionStart}
-                      onCompositionEnd={(e) => props.onSearchCompositionEnd((e.currentTarget as HTMLInputElement).value)}
-                      onKeyDown={(e) => {
-                        if (e.key !== 'Escape' || !props.searchInput) return;
-                        e.preventDefault();
-                        props.onClearSearch();
-                      }}
-                    />
-                    {!!props.searchInput && (
-                      <button
-                        type="button"
-                        className="search-clear-btn"
-                        aria-label={t('txt_clear_search')}
-                        title={t('txt_clear_search_esc')}
-                        onClick={props.onClearSearch}
-                      >
-                        <X size={14} />
-                      </button>
-                    )}
-                  </>
-                )}
-              </div>
+                  <button type="button" className="btn btn-secondary small" onClick={props.onSelectUniqueFromDuplicates}>
+                    <Check size={14} className="btn-icon" /> {t('txt_select_duplicate_items')}
+                  </button>
+                </div>
+              ) : (
+                <div className="search-input-wrap">
+                  <input
+                    className="search-input"
+                    placeholder={t('txt_search_items_count', { count: props.totalCipherCount })}
+                    value={props.searchInput}
+                    onInput={(e) => props.onSearchInput((e.currentTarget as HTMLInputElement).value)}
+                    onCompositionStart={props.onSearchCompositionStart}
+                    onCompositionEnd={(e) => props.onSearchCompositionEnd((e.currentTarget as HTMLInputElement).value)}
+                    onKeyDown={(e) => {
+                      if (e.key !== 'Escape' || !props.searchInput) return;
+                      e.preventDefault();
+                      props.onClearSearch();
+                    }}
+                  />
+                  {!!props.searchInput && (
+                    <button
+                      type="button"
+                      className="search-clear-btn"
+                      aria-label={t('txt_clear_search')}
+                      title={t('txt_clear_search_esc')}
+                      onClick={props.onClearSearch}
+                    >
+                      <X size={14} />
+                    </button>
+                  )}
+                </div>
+              )}
               {props.sidebarFilter.kind === 'duplicates' && !props.isMobileLayout && (
                 <div className="duplicate-mode-head-menu">
                   {renderMobileFilterMenu('duplicate', t('txt_duplicate_detection_mode'), duplicateModeSelected, <Copy size={14} />, duplicateModeOptions)}
@@ -387,7 +391,13 @@ export default function VaultListPanel(props: VaultListPanelProps) {
               <button type="button" className="btn btn-secondary small list-icon-btn" disabled={props.busy || props.loading} onClick={props.onSyncVault}>
                 <RefreshCw size={14} className="btn-icon" /> {t('txt_sync_vault')}
               </button>
-              {!props.isMobileLayout && props.sidebarFilter !== undefined && createMenu}
+              {props.sidebarFilter.kind === 'duplicates' && !props.isMobileLayout ? (
+                <button type="button" className="btn btn-secondary small" onClick={props.onSelectUniqueFromDuplicates}>
+                  <Check size={14} className="btn-icon" /> {t('txt_select_duplicate_items')}
+                </button>
+              ) : (
+                !props.isMobileLayout && props.sidebarFilter !== undefined && createMenu
+              )}
             </>
           )}
         </div>

--- a/webapp/src/lib/demo.ts
+++ b/webapp/src/lib/demo.ts
@@ -383,6 +383,143 @@ export const DEMO_CIPHERS: Cipher[] = [
       decFingerprint: 'SHA256:demoNodeWardenFingerprint',
     },
   },
+  // --- Duplicate detection demo pairs (exact, login-site, login-credentials, password) ---
+  {
+    id: 'cipher-dup-exact-a',
+    type: 1,
+    folderId: 'folder-work',
+    favorite: false,
+    name: 'Internal VPN',
+    decName: 'Internal VPN',
+    creationDate: '2026-04-10T08:00:00.000Z',
+    revisionDate: '2026-04-28T10:00:00.000Z',
+    login: {
+      username: 'vpn-user',
+      password: 'vpn-secret-2026', // gitguardian:ignore
+      decUsername: 'vpn-user',
+      decPassword: 'vpn-secret-2026', // gitguardian:ignore
+      uris: [{ uri: 'https://vpn.internal.example.com', decUri: 'https://vpn.internal.example.com', match: null }],
+    },
+  },
+  {
+    id: 'cipher-dup-exact-b',
+    type: 1,
+    folderId: 'folder-work',
+    favorite: false,
+    name: 'Internal VPN',
+    decName: 'Internal VPN',
+    creationDate: '2026-03-15T08:00:00.000Z',
+    revisionDate: '2026-04-30T10:00:00.000Z',
+    login: {
+      username: 'vpn-user',
+      password: 'vpn-secret-2026', // gitguardian:ignore
+      decUsername: 'vpn-user',
+      decPassword: 'vpn-secret-2026', // gitguardian:ignore
+      uris: [{ uri: 'https://vpn.internal.example.com', decUri: 'https://vpn.internal.example.com', match: null }],
+    },
+  },
+  {
+    id: 'cipher-dup-site-a',
+    type: 1,
+    folderId: 'folder-devops',
+    favorite: false,
+    name: 'AWS Console',
+    decName: 'AWS Console',
+    creationDate: '2026-03-01T08:00:00.000Z',
+    revisionDate: '2026-04-25T09:00:00.000Z',
+    login: {
+      username: 'aws-admin',
+      password: 'aws-secure-password', // gitguardian:ignore
+      decUsername: 'aws-admin',
+      decPassword: 'aws-secure-password', // gitguardian:ignore
+      uris: [{ uri: 'https://console.aws.amazon.com', decUri: 'https://console.aws.amazon.com', match: null }],
+    },
+  },
+  {
+    id: 'cipher-dup-site-b',
+    type: 1,
+    folderId: 'folder-devops',
+    favorite: false,
+    name: 'Amazon Web Services',
+    decName: 'Amazon Web Services',
+    creationDate: '2026-02-20T08:00:00.000Z',
+    revisionDate: '2026-04-20T09:00:00.000Z',
+    login: {
+      username: 'aws-admin',
+      password: 'aws-secure-password', // gitguardian:ignore
+      decUsername: 'aws-admin',
+      decPassword: 'aws-secure-password', // gitguardian:ignore
+      uris: [{ uri: 'https://console.aws.amazon.com', decUri: 'https://console.aws.amazon.com', match: null }],
+    },
+  },
+  {
+    id: 'cipher-dup-cred-a',
+    type: 1,
+    folderId: 'folder-personal',
+    favorite: false,
+    name: 'Personal Blog',
+    decName: 'Personal Blog',
+    creationDate: '2026-01-10T08:00:00.000Z',
+    revisionDate: '2026-04-15T10:00:00.000Z',
+    login: {
+      username: 'my-account@example.com',
+      password: 'shared-credential', // gitguardian:ignore
+      decUsername: 'my-account@example.com',
+      decPassword: 'shared-credential', // gitguardian:ignore
+      uris: [{ uri: 'https://blog.example.com', decUri: 'https://blog.example.com', match: null }],
+    },
+  },
+  {
+    id: 'cipher-dup-cred-b',
+    type: 1,
+    folderId: 'folder-personal',
+    favorite: false,
+    name: 'Forum Account',
+    decName: 'Forum Account',
+    creationDate: '2026-01-15T08:00:00.000Z',
+    revisionDate: '2026-04-18T10:00:00.000Z',
+    login: {
+      username: 'my-account@example.com',
+      password: 'shared-credential', // gitguardian:ignore
+      decUsername: 'my-account@example.com',
+      decPassword: 'shared-credential', // gitguardian:ignore
+      uris: [{ uri: 'https://forum.example.com', decUri: 'https://forum.example.com', match: null }],
+    },
+  },
+  {
+    id: 'cipher-dup-pw-a',
+    type: 1,
+    folderId: 'folder-personal',
+    favorite: false,
+    name: 'Old Forum',
+    decName: 'Old Forum',
+    creationDate: '2025-06-01T08:00:00.000Z',
+    revisionDate: '2026-03-01T10:00:00.000Z',
+    login: {
+      username: 'legacy-user',
+      password: 'reused-password-2020', // gitguardian:ignore
+      decUsername: 'legacy-user',
+      decPassword: 'reused-password-2020', // gitguardian:ignore
+      uris: [{ uri: 'https://old-forum.example.com', decUri: 'https://old-forum.example.com', match: null }],
+    },
+  },
+  {
+    id: 'cipher-dup-pw-b',
+    type: 1,
+    folderId: 'folder-personal',
+    favorite: false,
+    name: 'Legacy CMS',
+    decName: 'Legacy CMS',
+    creationDate: '2025-05-10T08:00:00.000Z',
+    revisionDate: '2026-02-15T10:00:00.000Z',
+    login: {
+      username: 'cms-admin',
+      password: 'reused-password-2020', // gitguardian:ignore
+      decUsername: 'cms-admin',
+      decPassword: 'reused-password-2020', // gitguardian:ignore
+      uris: [{ uri: 'https://cms.example.com', decUri: 'https://cms.example.com', match: null }],
+    },
+  },
   {
     id: 'cipher-archived',
     type: 1,

--- a/webapp/src/styles/responsive.css
+++ b/webapp/src/styles/responsive.css
@@ -427,6 +427,20 @@
     min-width: max(100%, 190px);
   }
 
+  .list-head .mobile-duplicate-toolbar {
+    @apply flex min-w-0 items-center gap-1.5;
+    flex: none;
+  }
+
+  .list-head .mobile-duplicate-mode-select-wrap {
+    max-width: 130px;
+    flex-shrink: 0;
+  }
+
+  .list-head .mobile-duplicate-mode-select-wrap .mobile-vault-filter-trigger {
+    @apply w-full;
+  }
+
   .toolbar.actions {
     @apply justify-end overflow-visible pb-0.5;
     flex-wrap: unset;


### PR DESCRIPTION
## Summary

  改进重复项检测的体验：在密码库重复项视图中，按颜色（相同重复组）将条目排在一起，组内外都按名称 A-Z 排序。之前切换到重复项视图时虽然强制排序模式为"名称"，但没有真正将相关的重复条目分组 —— 所有条目只是按名称线性排列，跨组比较困难。

  同时为 `dev:demo` 模式添加了覆盖全部 4 种重复检测模式的 demo 数据，方便直观测试。

  ## Change Type

  - [x] Bug 修复
  - [x] 新功能
  - [ ] 兼容性更新
  - [ ] 文档
  - [ ] 重构

  ## Cross-File Checklist

  - [x] 已阅读 `CONTRIBUTING.md`
  - [ ] 涉及 schema 变更时，已更新运行时 schema 和 `migrations/0001_init.sql`
  - [ ] 涉及持久化数据变更时，已更新备份导出/导入逻辑，或注明无需备份
  - [ ] 涉及用户可见文本变更时，已更新所有语言文件
  - [ ] 涉及 API 结构变更时，已考虑 Bitwarden 客户端兼容性
  - [ ] 不包含密钥、令牌、私有部署地址或真实密码库数据

  ## Checks

  - [x] `npx tsc -p tsconfig.json --noEmit`
  - [x] `npx tsc -p webapp/tsconfig.json --noEmit`
  - [ ] `npm run i18n:validate`
  - [ ] `npm run build`

  ## Notes

  ### 重复项排序逻辑（`VaultPage.tsx`）

  当 `sidebarFilter.kind === 'duplicates'` 时，排序函数现在：

  1. **预计算 `groupMinName`** — 每个重复组内按字母排序最靠前的名称（基于 `duplicateSignatureInfo`）
  2. **按颜色分组** — 共享同一重复签名的条目排在一起（相同颜色指示器）
  3. **组内排序** — 同一组内按名称 A-Z 排序
  4. **组间排序** — 不同组之间按组内第一条的名称 A-Z 排序（不再是原始签名字符串）
  5. **无组条目排最后** — 不属于任何重复组（出现次数 ≥2）的条目排在末尾

  原来的 `useEffect`（重复项视图时强制 `sortMode` 为 `'name'`）保留不变 —— 排序函数的特殊处理已经覆盖了排序逻辑，但保留这个 effect 可以让排序按钮高亮保持"名称"状态，避免 UI 不一致。

  ### Demo 数据（`demo.ts`）

  新增 8 条密码条目，组成 4 对重复数据（每种检测模式一对）：

  | 模式 | 条目对 | 关键特征 |
  |---|---|---|
  | `exact` | Internal VPN × 2 | 完全一致 |
  | `login-site` | AWS Console / Amazon Web Services | 同一站点 + 凭据 |
  | `login-credentials` | Personal Blog / Forum Account | 同一用户名 + 密码 |
  | `password` | Old Forum / Legacy CMS | 同一密码 |

  ### 功能处效果图：
<img width="590" height="491" alt="image" src="https://github.com/user-attachments/assets/cb7ecbc6-7416-4249-88d5-dfbae16bde90" />
