### PR TITLE
fix: auto-refresh remote backup directory when cache is stale [fix #310]

### DIFF
--- a/webapp/src/components/BackupCenterPage.tsx
+++ b/webapp/src/components/BackupCenterPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/lib/api/backup';
 import {
   REMOTE_BROWSER_ITEMS_PER_PAGE,
+  REMOTE_BROWSER_REFRESH_TTL_MS,
   compareRemoteItems,
   createDraftBackupSettings,
   createDraftDestinationRecord,
@@ -217,6 +218,7 @@ export default function BackupCenterPage(props: BackupCenterPageProps) {
   const [remoteBrowserCache, setRemoteBrowserCache] = useState<Record<string, RemoteBackupBrowserResponse>>(persistedRemoteState.cache);
   const [remoteBrowserPathByDestination, setRemoteBrowserPathByDestination] = useState<Record<string, string>>(persistedRemoteState.pathByDestination);
   const [remoteBrowserPageByKey, setRemoteBrowserPageByKey] = useState<Record<string, number>>(persistedRemoteState.pageByKey);
+  const [remoteBrowserRefreshedAt, setRemoteBrowserRefreshedAt] = useState<Record<string, number>>(persistedRemoteState.refreshedAt || {});
   const [showAddChooser, setShowAddChooser] = useState(false);
 
   const visibleDestinations = getVisibleDestinations(settings);
@@ -308,8 +310,22 @@ export default function BackupCenterPage(props: BackupCenterPageProps) {
       pathByDestination: remoteBrowserPathByDestination,
       pageByKey: remoteBrowserPageByKey,
       selectedDestinationId,
+      refreshedAt: remoteBrowserRefreshedAt,
     });
-  }, [props.currentUserId, remoteBrowserCache, remoteBrowserPageByKey, remoteBrowserPathByDestination, selectedDestinationId]);
+  }, [props.currentUserId, remoteBrowserCache, remoteBrowserPageByKey, remoteBrowserPathByDestination, remoteBrowserRefreshedAt, selectedDestinationId]);
+
+  useEffect(() => {
+    if (!savedSelectedDestination) return;
+    const destinationId = savedSelectedDestination.id;
+    const path = remoteBrowserPathByDestination[destinationId] || '';
+    const cacheKey = getRemoteBrowserCacheKey(destinationId, path);
+    const lastRefreshed = remoteBrowserRefreshedAt[cacheKey] || 0;
+    const isStale = Date.now() - lastRefreshed > REMOTE_BROWSER_REFRESH_TTL_MS;
+    if (isStale) {
+      void loadRemoteBrowser(destinationId, path, { force: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [savedSelectedDestination?.id]);
 
   useEffect(() => {
     if (!restoreProgress) {
@@ -398,6 +414,7 @@ export default function BackupCenterPage(props: BackupCenterPageProps) {
       };
       setRemoteBrowserCache((current) => ({ ...current, [cacheKey]: nextBrowser }));
       setRemoteBrowserPageByKey((current) => ({ ...current, [cacheKey]: 1 }));
+      setRemoteBrowserRefreshedAt((current) => ({ ...current, [cacheKey]: Date.now() }));
     } catch (error) {
       const message = error instanceof Error ? error.message : t('txt_backup_remote_load_failed');
       setLocalError(message);
@@ -543,6 +560,7 @@ export default function BackupCenterPage(props: BackupCenterPageProps) {
       ).cache);
       setRemoteBrowserPathByDestination((current) => Object.fromEntries(Object.entries(current).filter(([key]) => key !== destinationIdToDelete)));
       setRemoteBrowserPageByKey((current) => Object.fromEntries(Object.entries(current).filter(([key]) => !key.startsWith(`${destinationIdToDelete}:`))));
+      setRemoteBrowserRefreshedAt((current) => Object.fromEntries(Object.entries(current).filter(([key]) => !key.startsWith(`${destinationIdToDelete}:`))));
       setSelectedDestinationId(nextSelected);
       setConfirmDeleteDestinationOpen(false);
       props.onNotify('success', t('txt_backup_destination_deleted'));
@@ -670,6 +688,7 @@ export default function BackupCenterPage(props: BackupCenterPageProps) {
         setRemoteBrowserCache((current) => Object.fromEntries(Object.entries(current).filter(([key]) => !key.startsWith(`${destinationIdToInvalidate}:`))));
         setRemoteBrowserPathByDestination((current) => Object.fromEntries(Object.entries(current).filter(([key]) => key !== destinationIdToInvalidate)));
         setRemoteBrowserPageByKey((current) => Object.fromEntries(Object.entries(current).filter(([key]) => !key.startsWith(`${destinationIdToInvalidate}:`))));
+        setRemoteBrowserRefreshedAt((current) => Object.fromEntries(Object.entries(current).filter(([key]) => !key.startsWith(`${destinationIdToInvalidate}:`))));
       }
       setSelectedDestinationId(nextSelected);
       props.onNotify('success', t('txt_backup_settings_saved'));

--- a/webapp/src/lib/backup-center.ts
+++ b/webapp/src/lib/backup-center.ts
@@ -14,10 +14,12 @@ export interface PersistedRemoteBrowserState {
   pathByDestination: Record<string, string>;
   pageByKey: Record<string, number>;
   selectedDestinationId: string | null;
+  refreshedAt: Record<string, number>;
 }
 
 export const REMOTE_BROWSER_STORAGE_KEY = 'nodewarden.backup.remote-browser.v1';
 export const REMOTE_BROWSER_ITEMS_PER_PAGE = 10;
+export const REMOTE_BROWSER_REFRESH_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 export const COMMON_TIME_ZONES = [
   'UTC',
@@ -148,6 +150,7 @@ export function loadPersistedRemoteBrowserState(userId?: string | null): Persist
         pathByDestination: {},
         pageByKey: {},
         selectedDestinationId: null,
+        refreshedAt: {},
       };
     }
     const parsed = JSON.parse(raw) as Partial<PersistedRemoteBrowserState>;
@@ -156,6 +159,7 @@ export function loadPersistedRemoteBrowserState(userId?: string | null): Persist
       pathByDestination: parsed.pathByDestination && typeof parsed.pathByDestination === 'object' ? parsed.pathByDestination : {},
       pageByKey: parsed.pageByKey && typeof parsed.pageByKey === 'object' ? parsed.pageByKey : {},
       selectedDestinationId: typeof parsed.selectedDestinationId === 'string' ? parsed.selectedDestinationId : null,
+      refreshedAt: parsed.refreshedAt && typeof parsed.refreshedAt === 'object' ? parsed.refreshedAt as Record<string, number> : {},
     };
   } catch {
     return {
@@ -163,6 +167,7 @@ export function loadPersistedRemoteBrowserState(userId?: string | null): Persist
       pathByDestination: {},
       pageByKey: {},
       selectedDestinationId: null,
+      refreshedAt: {},
     };
   }
 }


### PR DESCRIPTION

 ## Summary

  远端备份目录浏览器 (`RemoteBackupBrowser`) 会将远端存储的响应缓存到 localStorage 中以避免重复网络请求。此前，缓存只在用户手动点击"刷新"按钮或备份/删除操作后才会更新。如果用户在定时备份执行后进入页面，看到的仍然是旧数据。

  此变更在每个缓存键旁边记录上次刷新时间 (`refreshedAt`)。一个 `useEffect` 在选中目标变化时（包括首次挂载）触发，将当前时间与记录的时间戳对比，如果超过 5 分钟则强制重新拉取数据。

  ## Change Type

  - [ ] Bug fix
  - [x] Feature
  - [ ] Compatibility update
  - [ ] Documentation
  - [ ] Refactor

  ## Cross-File Checklist

  - [x] I read `CONTRIBUTING.md`.
  - [x] Schema changes, if any, updated both runtime schema and `migrations/0001_init.sql`.
  - [x] Persistent data changes, if any, updated backup export/import or documented why backup is not needed.
  - [x] User-facing text changes, if any, updated all locale files.
  - [x] Bitwarden client compatibility was considered for sync/API shape changes.
  - [x] No secrets, tokens, private deployment values, or real vault data are included.

  ## Checks

  - [x] `npx tsc -p tsconfig.json --noEmit`
  - [x] `npx tsc -p webapp/tsconfig.json --noEmit`
  - [ ] `npm run i18n:validate`
  - [x] `npm run build`

## Notes

# 远端备份目录刷新场景清单

## 触发刷新的场景

| # | 触发场景 | 触发机制 | force | 代码位置 |
|---|---|---|---|---|
| 1 | 进入页面，缓存过期 (>5min) | `useEffect` → `savedSelectedDestination?.id` 变化，检查 `refreshedAt` 过期 | `true` | `BackupCenterPage.tsx:317-328` |
| 2 | 进入页面，首次加载 (无缓存) | `lastRefreshed` 为 0 → 过期 | `true` | `BackupCenterPage.tsx:317-328` |
| 3 | 切换备份目标，新目标缓存过期 | `useEffect` 检测 `savedSelectedDestination?.id` 变化 | `true` | `BackupCenterPage.tsx:317-328` |
| 4 | 切换备份目标，新目标无缓存 | `lastRefreshed` 为 0 | `true` | `BackupCenterPage.tsx:317-328` |
| 5 | 手动点击刷新按钮 | `onRefreshRemoteBrowser` 回调 | `true` | `BackupCenterPage.tsx:1006-1010` |
| 6 | 运行手动备份后 | `executeRunRemoteBackup` 成功后 | `true` | `BackupCenterPage.tsx:714` |
| 7 | 删除远端备份文件后 | `executeDeleteRemote` 成功后 | `true` | `BackupCenterPage.tsx:762` |
| 8 | 保存目标设置后 | 清除该目标的全部缓存 + `refreshedAt`，下次触发时重新拉取 | 清除后自然触发 | `BackupCenterPage.tsx:687-692` |
| 9 | 删除备份目标后 | 清除该目标全部缓存 + `refreshedAt` | 清除后自然触发 | `BackupCenterPage.tsx:555-565` |

## 不触发刷新的场景

| # | 场景 | 原因 |
|---|---|---|
| 1 | 进入页面，缓存未过期 (5min内) | `Date.now() - lastRefreshed <= TTL`，跳过 |
| 2 | 在同一个目标下导航目录 (进入子目录/返回上级) | `savedSelectedDestination?.id` 不变，`useEffect` 不触发 |
| 3 | 浏览器标签页切换 (切换到其他标签页再切回来) | 没有 `visibilitychange` / `focus` 事件监听 |
| 4 | 其他用户操作了备份 (另一个浏览器/设备) | 没有 WebSocket / 轮询机制 |
| 5 | 定时备份任务成功执行后 | 定时备份是服务端执行的，不通知前端刷新 |

