### PR TITLE
feat: allow hiding TOTP codes by default (#319)

### DIFF
--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -139,6 +139,7 @@ function normalizeRoutePath(path: string): string {
   return normalized.length > 1 ? normalized.replace(/\/+$/, '') : '/';
 }
 const THEME_STORAGE_KEY = 'nodewarden.theme.preference.v1';
+const HIDE_TOTP_STORAGE_KEY = 'nodewarden.totp.hide-by-default.v1';
 const SIGNALR_RECORD_SEPARATOR = String.fromCharCode(0x1e);
 const SIGNALR_UPDATE_TYPE_SYNC_CIPHER_UPDATE = 0;
 const SIGNALR_UPDATE_TYPE_SYNC_CIPHER_CREATE = 1;
@@ -190,6 +191,15 @@ function readSessionTimeoutAction(): SessionTimeoutAction {
   if (typeof window === 'undefined') return 'lock';
   const value = String(window.localStorage.getItem(SESSION_TIMEOUT_ACTION_STORAGE_KEY) || '').trim();
   return value === 'logout' ? 'logout' : 'lock';
+}
+
+function readHideTotpByDefault(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(HIDE_TOTP_STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
 }
 
 export default function App() {
@@ -252,6 +262,7 @@ export default function App() {
   const [systemTheme, setSystemTheme] = useState<'light' | 'dark'>(() => resolveSystemTheme());
   const [lockTimeoutMinutes, setLockTimeoutMinutesState] = useState<LockTimeoutMinutes>(() => readLockTimeoutMinutes());
   const [sessionTimeoutAction, setSessionTimeoutActionState] = useState<SessionTimeoutAction>(() => readSessionTimeoutAction());
+  const [hideTotpByDefault, setHideTotpByDefault] = useState<boolean>(() => readHideTotpByDefault());
   const [unlockPreparing, setUnlockPreparing] = useState(() => initialBootstrap.phase === 'locked' && !initialBootstrap.session?.email);
   const [lockedSessionRefreshError, setLockedSessionRefreshError] = useState('');
   const [lockedSessionRetryKey, setLockedSessionRetryKey] = useState(0);
@@ -404,6 +415,15 @@ export default function App() {
     if (typeof window === 'undefined') return;
     window.localStorage.setItem(SESSION_TIMEOUT_ACTION_STORAGE_KEY, sessionTimeoutAction);
   }, [sessionTimeoutAction]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(HIDE_TOTP_STORAGE_KEY, hideTotpByDefault ? '1' : '0');
+    } catch {
+      // ignore storage errors
+    }
+  }, [hideTotpByDefault]);
 
   function handleToggleTheme() {
     setThemePreference((prev) => {
@@ -2038,6 +2058,7 @@ export default function App() {
     passkey2faEnabled: !!twoFactorStatusQuery.data?.passkeyEnabled,
     lockTimeoutMinutes,
     sessionTimeoutAction,
+    hideTotpByDefault,
     authorizedDevices: authorizedDevicesQuery.data || [],
     currentDeviceIdentifier: getCurrentDeviceIdentifier(),
     authorizedDevicesLoading: authorizedDevicesQuery.isFetching,
@@ -2049,6 +2070,7 @@ export default function App() {
     onLogout: handleLogout,
     onNotify: pushToast,
     onThemePreferenceChange: setThemePreference,
+    onHideTotpByDefaultChange: setHideTotpByDefault,
     onImport: vaultSendActions.importVault,
     onImportEncryptedRaw: vaultSendActions.importEncryptedRaw,
     onExport: vaultSendActions.exportVault,

--- a/webapp/src/components/AppMainRoutes.tsx
+++ b/webapp/src/components/AppMainRoutes.tsx
@@ -42,6 +42,7 @@ export interface AppMainRoutesProps {
   mobileLayout: boolean;
   mobileSidebarToggleKey: number;
   themePreference: 'system' | 'light' | 'dark';
+  hideTotpByDefault: boolean;
   importRoute: string;
   settingsHomeRoute: string;
   settingsAccountRoute: string;
@@ -61,6 +62,7 @@ export interface AppMainRoutesProps {
   passkey2faEnabled: boolean;
   lockTimeoutMinutes: 0 | 1 | 5 | 15 | 30;
   sessionTimeoutAction: 'lock' | 'logout';
+  onHideTotpByDefaultChange: (value: boolean) => void;
   authorizedDevices: AuthorizedDevice[];
   currentDeviceIdentifier: string;
   authorizedDevicesLoading: boolean;
@@ -248,7 +250,7 @@ export default function AppMainRoutes(props: AppMainRoutesProps) {
       </Route>
       <Route path="/vault/totp">
         <Suspense fallback={<RouteContentFallback />}>
-          <TotpCodesPage ciphers={props.decryptedCiphers} loading={props.ciphersLoading} onNotify={props.onNotify} />
+          <TotpCodesPage ciphers={props.decryptedCiphers} loading={props.ciphersLoading} onNotify={props.onNotify} hideTotpByDefault={props.hideTotpByDefault} />
         </Suspense>
       </Route>
       <Route path="/vault">
@@ -284,6 +286,7 @@ export default function AppMainRoutes(props: AppMainRoutesProps) {
             uploadingAttachmentName={props.uploadingAttachmentName}
             attachmentUploadPercent={props.attachmentUploadPercent}
             mobileSidebarToggleKey={props.mobileSidebarToggleKey}
+            hideTotpByDefault={props.hideTotpByDefault}
           />
         </Suspense>
       </Route>
@@ -305,9 +308,11 @@ export default function AppMainRoutes(props: AppMainRoutesProps) {
                 yubikeyEnabled={props.yubikeyEnabled}
                 passkey2faEnabled={props.passkey2faEnabled}
                 themePreference={props.themePreference}
+                hideTotpByDefault={props.hideTotpByDefault}
                 lockTimeoutMinutes={props.lockTimeoutMinutes}
                 sessionTimeoutAction={props.sessionTimeoutAction}
                 onThemePreferenceChange={props.onThemePreferenceChange}
+                onHideTotpByDefaultChange={props.onHideTotpByDefaultChange}
                 onVerifyMasterPassword={props.onVerifyMasterPassword}
                 onChangePassword={props.onChangePassword}
                 onSavePasswordHint={props.onSavePasswordHint}

--- a/webapp/src/components/SettingsPage.tsx
+++ b/webapp/src/components/SettingsPage.tsx
@@ -12,9 +12,11 @@ interface SettingsPageProps {
   yubikeyEnabled: boolean;
   passkey2faEnabled: boolean;
   themePreference: ThemePreference;
+  hideTotpByDefault: boolean;
   lockTimeoutMinutes: 0 | 1 | 5 | 15 | 30;
   sessionTimeoutAction: 'lock' | 'logout';
   onThemePreferenceChange: (preference: ThemePreference) => void;
+  onHideTotpByDefaultChange: (value: boolean) => void;
   onVerifyMasterPassword: (email: string, password: string) => Promise<void>;
   onChangePassword: (currentPassword: string, nextPassword: string, nextPassword2: string) => Promise<void>;
   onSavePasswordHint: (masterPasswordHint: string) => Promise<void>;
@@ -570,6 +572,20 @@ export default function SettingsPage(props: SettingsPageProps) {
                   </select>
                   <div className="field-help">{t('txt_theme_saved_locally')}</div>
                 </label>
+              </section>
+
+              <section className="settings-submodule">
+                <div className="settings-checkbox-block">
+                  <label className="checkbox-inline">
+                    <input
+                      type="checkbox"
+                      checked={props.hideTotpByDefault}
+                      onInput={(e) => props.onHideTotpByDefaultChange((e.currentTarget as HTMLInputElement).checked)}
+                    />
+                    <span>{t('txt_hide_totp_by_default')}</span>
+                  </label>
+                  <div className="field-help">{t('txt_hide_totp_by_default_help')}</div>
+                </div>
               </section>
 
               <section className="settings-submodule">

--- a/webapp/src/components/TotpCodesPage.tsx
+++ b/webapp/src/components/TotpCodesPage.tsx
@@ -1,17 +1,18 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
-import { Clipboard, Globe } from 'lucide-preact';
+import { Clipboard, Eye, EyeOff, Globe } from 'lucide-preact';
 import { copyTextToClipboard as copyTextWithFeedback } from '@/lib/clipboard';
 import { calcTotpNow, type TotpCodeResult } from '@/lib/crypto';
 import { t } from '@/lib/i18n';
 import type { Cipher } from '@/lib/types';
 import LoadingState from '@/components/LoadingState';
 import WebsiteIcon from '@/components/vault/WebsiteIcon';
-import { formatTotp, isCipherVisibleInNormalVault } from '@/components/vault/vault-page-helpers';
+import { formatTotp, isCipherVisibleInNormalVault, maskSecret } from '@/components/vault/vault-page-helpers';
 
 interface TotpCodesPageProps {
   ciphers: Cipher[];
   loading: boolean;
   onNotify: (type: 'success' | 'error', text: string) => void;
+  hideTotpByDefault: boolean;
 }
 
 const TOTP_RING_RADIUS = 14;
@@ -26,6 +27,9 @@ interface TotpRowProps {
   cipher: Cipher;
   live: TotpCodeResult | null;
   onCopy: (value: string) => void;
+  hideTotpByDefault: boolean;
+  revealed: boolean;
+  onToggleReveal: () => void;
 }
 
 function TotpRow(props: TotpRowProps) {
@@ -33,6 +37,7 @@ function TotpRow(props: TotpRowProps) {
   const username = props.cipher.login?.decUsername || '';
   const period = Math.max(1, props.live?.period || 30);
   const progress = props.live ? Math.max(0, Math.min(period, props.live.remain)) / period : 0;
+  const hidden = props.hideTotpByDefault && !props.revealed;
 
   return (
     <div className="totp-code-row">
@@ -46,7 +51,7 @@ function TotpRow(props: TotpRowProps) {
         </div>
       </div>
       <div className="totp-code-main">
-        <strong>{props.live ? formatTotp(props.live.code) : t('txt_text_3')}</strong>
+        <strong>{props.live ? (hidden ? maskSecret(props.live.code) : formatTotp(props.live.code)) : t('txt_text_3')}</strong>
         <div
           className="totp-timer"
           title={t('txt_refresh_in_seconds_s', { seconds: props.live ? props.live.remain : 0 })}
@@ -73,6 +78,17 @@ function TotpRow(props: TotpRowProps) {
         <button type="button" className="btn btn-secondary small totp-copy-btn" onClick={() => props.onCopy(props.live?.code || '')} aria-label={t('txt_copy')}>
           <Clipboard size={14} className="btn-icon" />
         </button>
+        {props.hideTotpByDefault && (
+          <button
+            type="button"
+            className="btn btn-secondary small totp-copy-btn"
+            onClick={props.onToggleReveal}
+            aria-label={hidden ? t('txt_reveal') : t('txt_hide')}
+            title={hidden ? t('txt_reveal') : t('txt_hide')}
+          >
+            {hidden ? <Eye size={14} className="btn-icon" /> : <EyeOff size={14} className="btn-icon" />}
+          </button>
+        )}
       </div>
     </div>
   );
@@ -81,7 +97,17 @@ function TotpRow(props: TotpRowProps) {
 export default function TotpCodesPage(props: TotpCodesPageProps) {
   const [totpCodes, setTotpCodes] = useState<Record<string, TotpCodeResult | null>>({});
   const [columnCount, setColumnCount] = useState(1);
+  const [revealedIds, setRevealedIds] = useState<Set<string>>(() => new Set());
   const listRef = useRef<HTMLDivElement | null>(null);
+
+  function toggleReveal(cipherId: string) {
+    setRevealedIds((current) => {
+      const next = new Set(current);
+      if (next.has(cipherId)) next.delete(cipherId);
+      else next.add(cipherId);
+      return next;
+    });
+  }
 
   async function copyToClipboard(value: string): Promise<void> {
     await copyTextWithFeedback(value, { successMessage: t('txt_code_copied') });
@@ -209,6 +235,9 @@ export default function TotpCodesPage(props: TotpCodesPageProps) {
               cipher={cipher}
               live={totpCodes[cipher.id] || null}
               onCopy={(value) => void copyToClipboard(value)}
+              hideTotpByDefault={props.hideTotpByDefault}
+              revealed={revealedIds.has(cipher.id)}
+              onToggleReveal={() => toggleReveal(cipher.id)}
             />
           ))}
         </div>

--- a/webapp/src/components/VaultPage.tsx
+++ b/webapp/src/components/VaultPage.tsx
@@ -68,6 +68,7 @@ interface VaultPageProps {
   uploadingAttachmentName: string;
   attachmentUploadPercent: number | null;
   mobileSidebarToggleKey: number;
+  hideTotpByDefault: boolean;
 }
 
 
@@ -89,6 +90,7 @@ export default function VaultPage(props: VaultPageProps) {
   const [selectedMap, setSelectedMap] = useState<Record<string, boolean>>({});
   const pendingFocusCipherIdRef = useRef<string | null>(null);
   const [showPassword, setShowPassword] = useState(false);
+  const [showTotp, setShowTotp] = useState(false);
   const [createMenuOpen, setCreateMenuOpen] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
@@ -272,6 +274,7 @@ export default function VaultPage(props: VaultPageProps) {
     setRepromptPassword('');
     setRepromptOpen(false);
     setShowPassword(false);
+    setShowTotp(false);
     setHiddenFieldVisibleMap({});
   }, [selectedCipherId]);
 
@@ -1335,11 +1338,14 @@ const folderName = useCallback((id: string | null | undefined): string => {
                 repromptApprovedCipherId={repromptApprovedCipherId}
                 showPassword={showPassword}
                 totpLive={totpLive}
+                hideTotpByDefault={props.hideTotpByDefault}
+                showTotp={showTotp}
                 passkeyCreatedAt={firstPasskeyCreationTime(selectedCipher)}
                 hiddenFieldVisibleMap={hiddenFieldVisibleMap}
                 folderName={folderName}
                 onOpenReprompt={() => setRepromptOpen(true)}
                 onToggleShowPassword={() => setShowPassword((value) => !value)}
+                onToggleShowTotp={() => setShowTotp((value) => !value)}
                 onToggleHiddenField={(index) => setHiddenFieldVisibleMap((prev) => ({ ...prev, [index]: !prev[index] }))}
                 onDownloadAttachment={(cipher, attachmentId) => void props.onDownloadAttachment(cipher, attachmentId)}
                 downloadingAttachmentKey={props.downloadingAttachmentKey}

--- a/webapp/src/components/vault/VaultDetailView.tsx
+++ b/webapp/src/components/vault/VaultDetailView.tsx
@@ -31,6 +31,8 @@ interface VaultDetailViewProps {
   repromptApprovedCipherId: string | null;
   showPassword: boolean;
   totpLive: TotpCodeResult | null;
+  hideTotpByDefault: boolean;
+  showTotp: boolean;
   passkeyCreatedAt: string | null;
   hiddenFieldVisibleMap: Record<number, boolean>;
   folderName: (id: string | null | undefined) => string;
@@ -38,6 +40,7 @@ interface VaultDetailViewProps {
   attachmentDownloadPercent: number | null;
   onOpenReprompt: () => void;
   onToggleShowPassword: () => void;
+  onToggleShowTotp: () => void;
   onToggleHiddenField: (index: number) => void;
   onDownloadAttachment: (cipher: Cipher, attachmentId: string) => void;
   onStartEdit: () => void;
@@ -227,7 +230,7 @@ export default function VaultDetailView(props: VaultDetailViewProps) {
                   <span className="kv-label">{t('txt_totp')}</span>
                   <div className="kv-main">
                     <div className="totp-inline">
-                      <strong>{props.totpLive ? formatTotp(props.totpLive.code) : t('txt_text_3')}</strong>
+                      <strong>{props.totpLive ? (props.hideTotpByDefault && !props.showTotp ? maskSecret(props.totpLive.code) : formatTotp(props.totpLive.code)) : t('txt_text_3')}</strong>
                       <div
                         className="totp-timer"
                         title={t('txt_refresh_in_seconds_s', { seconds: props.totpLive ? props.totpLive.remain : 0 })}
@@ -254,6 +257,12 @@ export default function VaultDetailView(props: VaultDetailViewProps) {
                     </div>
                   </div>
                   <div className="kv-actions">
+                    {props.hideTotpByDefault && (
+                      <button type="button" className="btn btn-secondary small" onClick={props.onToggleShowTotp}>
+                        {props.showTotp ? <EyeOff size={14} className="btn-icon" /> : <Eye size={14} className="btn-icon" />}
+                        {props.showTotp ? t('txt_hide') : t('txt_reveal')}
+                      </button>
+                    )}
                     <button type="button" className="btn btn-secondary small" onClick={() => copyToClipboard(props.totpLive?.code || '')}>
                       <Clipboard size={14} className="btn-icon" /> {t('txt_copy')}
                     </button>

--- a/webapp/src/lib/i18n/locales/de.ts
+++ b/webapp/src/lib/i18n/locales/de.ts
@@ -20,6 +20,8 @@ const de: Record<string, string> = {
   "txt_light_theme": "Hell",
   "txt_dark_theme": "Dunkel",
   "txt_theme_saved_locally": "Wählen Sie ein Design für Ihren Web-Tresor.",
+  "txt_hide_totp_by_default": "Verifizierungscodes standardmäßig ausblenden",
+  "txt_hide_totp_by_default_help": "TOTP-Codes maskieren, bis du sie einblendest.",
   "txt_display_language_help": "Ändern Sie die Sprache des Web-Tresors.",
   "txt_two_step_login": "Zweistufige Anmeldung",
   "txt_keys": "Schlüssel",

--- a/webapp/src/lib/i18n/locales/en.ts
+++ b/webapp/src/lib/i18n/locales/en.ts
@@ -43,6 +43,8 @@ const en: Record<string, string> = {
   "txt_light_theme": "Light",
   "txt_dark_theme": "Dark",
   "txt_theme_saved_locally": "Choose a theme for your web vault.",
+  "txt_hide_totp_by_default": "Hide verification codes by default",
+  "txt_hide_totp_by_default_help": "Mask TOTP codes until you choose to reveal them.",
   "txt_display_language_help": "Change the web vault language.",
   "txt_two_step_login": "Two-step login",
   "txt_keys": "Keys",

--- a/webapp/src/lib/i18n/locales/es.ts
+++ b/webapp/src/lib/i18n/locales/es.ts
@@ -20,6 +20,8 @@ const es: Record<string, string> = {
   "txt_light_theme": "Claro",
   "txt_dark_theme": "Oscuro",
   "txt_theme_saved_locally": "Elige un tema para tu bóveda web.",
+  "txt_hide_totp_by_default": "Ocultar los códigos de verificación de forma predeterminada",
+  "txt_hide_totp_by_default_help": "Oculta los códigos TOTP hasta que decidas mostrarlos.",
   "txt_display_language_help": "Cambia el idioma de la bóveda web.",
   "txt_two_step_login": "Inicio de sesión en dos pasos",
   "txt_keys": "Claves",

--- a/webapp/src/lib/i18n/locales/fi.ts
+++ b/webapp/src/lib/i18n/locales/fi.ts
@@ -20,6 +20,8 @@ const fi: Record<string, string> = {
   "txt_light_theme": "Vaalea",
   "txt_dark_theme": "Tumma",
   "txt_theme_saved_locally": "Valitse teema web-holvillesi.",
+  "txt_hide_totp_by_default": "Piilota vahvistuskoodit oletuksena",
+  "txt_hide_totp_by_default_help": "Peitä TOTP-koodit, kunnes valitset niiden näyttämisen.",
   "txt_display_language_help": "Vaihda web-holvin kieltä.",
   "txt_two_step_login": "Kaksivaiheinen kirjautuminen",
   "txt_keys": "Avaimet",

--- a/webapp/src/lib/i18n/locales/fr.ts
+++ b/webapp/src/lib/i18n/locales/fr.ts
@@ -20,6 +20,8 @@ const fr: Record<string, string> = {
   "txt_light_theme": "Clair",
   "txt_dark_theme": "Sombre",
   "txt_theme_saved_locally": "Choisissez un thème pour votre coffre-fort Web.",
+  "txt_hide_totp_by_default": "Masquer les codes de vérification par défaut",
+  "txt_hide_totp_by_default_help": "Masque les codes TOTP jusqu'à ce que vous choisissiez de les afficher.",
   "txt_display_language_help": "Modifier la langue du coffre-fort Web.",
   "txt_two_step_login": "Connexion en deux étapes",
   "txt_keys": "Clés",

--- a/webapp/src/lib/i18n/locales/it.ts
+++ b/webapp/src/lib/i18n/locales/it.ts
@@ -20,6 +20,8 @@ const it: Record<string, string> = {
   "txt_light_theme": "Chiaro",
   "txt_dark_theme": "Scuro",
   "txt_theme_saved_locally": "Scegli un tema per la tua cassaforte web.",
+  "txt_hide_totp_by_default": "Nascondi i codici di verifica per impostazione predefinita",
+  "txt_hide_totp_by_default_help": "Nascondi i codici TOTP finché non scegli di mostrarli.",
   "txt_display_language_help": "Cambia la lingua della cassaforte web.",
   "txt_two_step_login": "Accesso in due passaggi",
   "txt_keys": "Chiavi",

--- a/webapp/src/lib/i18n/locales/ru.ts
+++ b/webapp/src/lib/i18n/locales/ru.ts
@@ -21,6 +21,8 @@ const ru: Record<string, string> = {
   "txt_light_theme": "Светлая",
   "txt_dark_theme": "Темная",
   "txt_theme_saved_locally": "Выберите тему для веб-хранилища.",
+  "txt_hide_totp_by_default": "Скрывать коды подтверждения по умолчанию",
+  "txt_hide_totp_by_default_help": "Маскировать коды TOTP, пока вы их не отобразите.",
   "txt_display_language_help": "Изменить язык веб-хранилища.",
   "txt_two_step_login": "Двухэтапный вход",
   "txt_keys": "Ключи",

--- a/webapp/src/lib/i18n/locales/sv.ts
+++ b/webapp/src/lib/i18n/locales/sv.ts
@@ -20,6 +20,8 @@ const sv: Record<string, string> = {
   "txt_light_theme": "Ljust",
   "txt_dark_theme": "Mörkt",
   "txt_theme_saved_locally": "Välj ett tema för ditt webbvalv.",
+  "txt_hide_totp_by_default": "Dölj verifieringskoder som standard",
+  "txt_hide_totp_by_default_help": "Maskera TOTP-koder tills du väljer att visa dem.",
   "txt_display_language_help": "Ändra webbvalvets språk.",
   "txt_two_step_login": "Tvåstegsinloggning",
   "txt_keys": "Nycklar",

--- a/webapp/src/lib/i18n/locales/zh-CN.ts
+++ b/webapp/src/lib/i18n/locales/zh-CN.ts
@@ -23,6 +23,8 @@ const zhCN: Record<string, string> = {
   "txt_light_theme": "浅色",
   "txt_dark_theme": "深色",
   "txt_theme_saved_locally": "为您的网页密码库选择一个主题。",
+  "txt_hide_totp_by_default": "默认隐藏验证码",
+  "txt_hide_totp_by_default_help": "遮罩 TOTP 验证码，直到您选择显示。",
   "txt_display_language_help": "更改网页密码库的语言。",
   "txt_two_step_login": "两步登录",
   "txt_keys": "密钥",

--- a/webapp/src/lib/i18n/locales/zh-TW.ts
+++ b/webapp/src/lib/i18n/locales/zh-TW.ts
@@ -23,6 +23,8 @@ const zhTW: Record<string, string> = {
   "txt_light_theme": "淺色",
   "txt_dark_theme": "深色",
   "txt_theme_saved_locally": "為您的網頁密碼庫選擇一個主題。",
+  "txt_hide_totp_by_default": "預設隱藏驗證碼",
+  "txt_hide_totp_by_default_help": "遮罩 TOTP 驗證碼，直到您選擇顯示。",
   "txt_display_language_help": "更改網頁密碼庫的語言。",
   "txt_two_step_login": "兩步登入",
   "txt_keys": "密鑰",


### PR DESCRIPTION
## Summary

  Closes #319.

  控制面板此前默认以明文显示 TOTP 验证码。本 PR 在「设置 > 外观」下新增一个本地偏好「默认隐藏验证码（Hide verification codes by default）」。开启后，验证码面板和密码项详情中的 TOTP 会用星号遮罩，点击眼睛图标后才显示。复制按钮始终复制真实验证码。

  该偏好保存在 localStorage（默认关闭，因此现有行为不变），并复用代码库已有的 `maskSecret` + Eye/EyeOff 约定。新增 `txt_hide_totp_by_default[_help]` 文案，覆盖全部 10 种语言。

  涉及的界面：
  - `TotpCodesPage` —— 逐条显隐（用 `Set<string>` 记录已展开的 cipher ID，参照 `PasswordSecurityPage` 的实现）
  - `VaultDetailView` —— 在 `showPassword` 旁新增 `showTotp` 状态，切换条目时重置
  - 遮罩仅作用于显示层；复制按钮读取的是底层的 `live.code`，因此遮罩态下复制得到的仍是当前真实验证码。

  ## Change Type

  - [ ] Bug fix
  - [x] Feature
  - [ ] Compatibility update
  - [ ] Documentation
  - [ ] Refactor

  ## Cross-File Checklist

  - [x] I read `CONTRIBUTING.md`.
  - [ ] Schema changes, if any, updated both runtime schema and `migrations/0001_init.sql`.
  - [ ] Persistent data changes, if any, updated backup export/import or documented why backup is not needed.
  - [x] User-facing text changes, if any, updated all locale files.
  - [ ] Bitwarden client compatibility was considered for sync/API shape changes.
  - [x] No secrets, tokens, private deployment values, or real vault data are included.

  ## Checks

  - [x] `npx tsc -p tsconfig.json --noEmit`
  - [ ] `npx tsc -p webapp/tsconfig.json --noEmit`
  - [x] `npm run i18n:validate`
  - [x] `npm run build`

  ## Notes

  - 无 schema 或持久化数据改动——该偏好仅为客户端 localStorage（`nodewarden.totp.hide-by-default.v1`），因此不涉及备份/导入导出或数据库。上面两条未勾选的「if any」项即因此属于 N/A；Bitwarden 同步/API 形状完全未改（纯前端改动）。
  - `npx tsc -p webapp/tsconfig.json --noEmit` 未勾选，是因为它在 `main` 上就存在 **4 个预存错误**，且都在本 PR
  未触及的文件中（`webapp/src/lib/api/backup.ts`、`webapp/src/lib/backup-center.ts`、`webapp/src/lib/password-security-cache.ts`、`webapp/vite.config.ts`）。这些错误并非本次改动引入或影响——本次修改的 6个组件文件均类型检查通过。后端 `tsc`、`i18n:validate` 和 `npm run build` 全部通过。
  - 默认关闭，未开启该开关的用户看到的界面与当前完全一致（不会渲染任何新按钮）。


## 截图
<img width="851" height="511" alt="image" src="https://github.com/user-attachments/assets/26332e98-db92-4a41-b879-fd4ef5c055ac" />

<img width="1517" height="243" alt="image" src="https://github.com/user-attachments/assets/91e7fbe9-3d24-41d7-9692-fd57c78d3606" />

