### PR TITLE
Implement direct fetch for connector HTML pages and WebAuthn support

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "domains:sync": "node scripts/sync-global-domains.mjs",
     "i18n": "node scripts/i18n-validate.cjs",
     "i18n:validate": "node scripts/i18n-validate.cjs",
+    "test:webauthn-mobile": "node --test scripts/webauthn-mobile-connector.test.mjs",
     "deploy": "wrangler deploy",
     "deploy:kv": "node scripts/ensure-kv.cjs && wrangler deploy -c wrangler.kv.toml",
     "deploy:demo": "npm run build:demo && wrangler pages deploy dist --project-name nw-demo"

--- a/scripts/webauthn-mobile-connector.test.mjs
+++ b/scripts/webauthn-mobile-connector.test.mjs
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import {
+  base64UrlFromBuffer,
+  buildCallbackUrl,
+  buildCredentialData,
+  decodeBase64Utf8,
+  normalizePublicKeyOptions,
+  parseConnectorRequest,
+  resolveMobileCallbackUri,
+} from '../webapp/public/webauthn-mobile-connector.js';
+
+function encodeBase64Utf8(value) {
+  return Buffer.from(value, 'utf8').toString('base64');
+}
+
+function v2Search(payload, extra = '') {
+  return `?data=${encodeURIComponent(encodeBase64Utf8(JSON.stringify(payload)))}&parent=bitwarden%3A__webauthn-callback&v=2${extra}`;
+}
+
+const assertionOptions = {
+  challenge: 'AQID-v8',
+  rpId: 'pass.lvguangfa.cn',
+  timeout: 60000,
+  userVerification: 'preferred',
+  allowCredentials: [{ id: 'BAUGBwg', type: 'public-key', transports: ['internal'] }],
+};
+
+test('parses the current Bitwarden iOS V2 connector payload', () => {
+  const request = parseConnectorRequest(v2Search({
+    btnReturnText: 'Return to app',
+    btnText: 'Authenticate',
+    callbackUri: 'bitwarden://webauthn-callback',
+    data: JSON.stringify(assertionOptions),
+    headerText: 'Verify your identity',
+  }), 'pass.lvguangfa.cn');
+
+  assert.equal(request.callbackUri, 'bitwarden://webauthn-callback');
+  assert.equal(request.headerText, 'Verify your identity');
+  assert.equal(request.buttonText, 'Authenticate');
+  assert.equal(request.returnButtonText, 'Return to app');
+  assert.deepEqual(JSON.parse(request.webauthnJson), assertionOptions);
+});
+
+test('uses callbackUri only as a mobile signal and rejects callback injection', () => {
+  const request = parseConnectorRequest(v2Search({
+    callbackUri: 'https://attacker.example/capture',
+    data: JSON.stringify(assertionOptions),
+  }), 'pass.lvguangfa.cn');
+
+  assert.equal(request.callbackUri, 'bitwarden://webauthn-callback');
+});
+
+test('supports current Android custom-scheme and app-link callbacks', () => {
+  const payload = { mobile: true, data: JSON.stringify(assertionOptions) };
+  const custom = parseConnectorRequest(v2Search(payload, '&client=mobile&deeplinkScheme=bitwarden'));
+  const appLink = parseConnectorRequest(v2Search(payload, '&client=mobile&deeplinkScheme=https'), 'vault.bitwarden.eu');
+  const selfHostedAppLink = parseConnectorRequest(v2Search(payload, '&client=mobile&deeplinkScheme=https'), 'pass.lvguangfa.cn');
+
+  assert.equal(custom.callbackUri, 'bitwarden://webauthn-callback');
+  assert.equal(appLink.callbackUri, 'https://bitwarden.eu/webauthn-callback');
+  assert.equal(selfHostedAppLink.callbackUri, 'https://bitwarden.com/webauthn-callback');
+});
+
+test('supports legacy mobile markers without allowing arbitrary parent redirects', () => {
+  const request = parseConnectorRequest(
+    `?data=${encodeURIComponent(encodeBase64Utf8(JSON.stringify(assertionOptions)))}&v=1&client=mobile&parent=${encodeURIComponent('https://attacker.example')}`,
+  );
+  assert.equal(request.callbackUri, 'bitwarden://webauthn-callback');
+});
+
+test('requires a recognized mobile flow', () => {
+  assert.equal(resolveMobileCallbackUri({ payload: {}, hostname: 'pass.lvguangfa.cn' }), null);
+  assert.throws(
+    () => parseConnectorRequest(v2Search({ data: JSON.stringify(assertionOptions) }).replace('&parent=bitwarden%3A__webauthn-callback', '')),
+    /return target/i,
+  );
+});
+
+test('decodes UTF-8 Base64 and normalizes WebAuthn binary fields without mutating input', () => {
+  assert.equal(decodeBase64Utf8(encodeBase64Utf8('验证身份')), '验证身份');
+  const original = structuredClone(assertionOptions);
+  const normalized = normalizePublicKeyOptions(JSON.stringify(original));
+
+  assert.deepEqual(Array.from(normalized.challenge), [1, 2, 3, 250, 255]);
+  assert.deepEqual(Array.from(normalized.allowCredentials[0].id), [4, 5, 6, 7, 8]);
+  assert.equal(original.challenge, assertionOptions.challenge);
+  assert.equal(original.allowCredentials[0].id, assertionOptions.allowCredentials[0].id);
+});
+
+test('serializes credentials in the exact shape consumed by Bitwarden mobile', () => {
+  const serialized = JSON.parse(buildCredentialData({
+    id: 'credential-id',
+    rawId: Uint8Array.from([1, 2, 255]).buffer,
+    type: 'public-key',
+    getClientExtensionResults: () => ({ appid: false }),
+    response: {
+      authenticatorData: Uint8Array.from([3, 4]).buffer,
+      clientDataJSON: Uint8Array.from([5, 6]).buffer,
+      signature: Uint8Array.from([7, 8]).buffer,
+    },
+  }));
+
+  assert.deepEqual(serialized, {
+    id: 'credential-id',
+    rawId: 'AQL_',
+    type: 'public-key',
+    extensions: { appid: false },
+    response: {
+      authenticatorData: 'AwQ',
+      clientDataJson: 'BQY',
+      signature: 'Bwg',
+    },
+  });
+  assert.equal(base64UrlFromBuffer(Uint8Array.from([251, 255])), '-_8');
+});
+
+test('encodes result and error callbacks safely', () => {
+  assert.equal(
+    buildCallbackUrl('bitwarden://webauthn-callback', 'data', '{"id":"a+b"}'),
+    'bitwarden://webauthn-callback?data=%7B%22id%22%3A%22a%2Bb%22%7D',
+  );
+  assert.equal(
+    buildCallbackUrl('bitwarden://webauthn-callback?source=nodewarden', 'error', 'Not allowed'),
+    'bitwarden://webauthn-callback?source=nodewarden&error=Not%20allowed',
+  );
+});
+
+test('HTML provides the branded mobile UI and loads the connector module', async () => {
+  const html = await readFile(new URL('../webapp/public/webauthn-mobile-connector.html', import.meta.url), 'utf8');
+  assert.match(html, /id="webauthn-header"/);
+  assert.match(html, /id="webauthn-button"/);
+  assert.match(html, /src="\/nodewarden-logo\.svg"/);
+  assert.match(html, /src="\/webauthn-mobile-connector\.js"/);
+  assert.match(html, /prefers-color-scheme: dark/);
+  assert.match(html, /default-src 'none'/);
+});

--- a/webapp/public/webauthn-mobile-connector.html
+++ b/webapp/public/webauthn-mobile-connector.html
@@ -1,0 +1,278 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#f3f6f9" />
+    <meta name="color-scheme" content="light dark" />
+    <meta name="referrer" content="no-referrer" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; script-src 'self'; style-src 'unsafe-inline'; img-src 'self'; base-uri 'none'; form-action 'none'"
+    />
+    <title>NodeWarden WebAuthn</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #f3f6f9;
+        --panel: rgba(255, 255, 255, 0.94);
+        --panel-soft: #f8fafc;
+        --line: rgba(100, 116, 139, 0.22);
+        --line-soft: rgba(100, 116, 139, 0.13);
+        --text: #0f172a;
+        --muted: #64748b;
+        --primary: #2563eb;
+        --primary-hover: #1d4ed8;
+        --primary-soft: #eaf2ff;
+        --success: #047857;
+        --success-soft: #ecfdf5;
+        --danger: #b91c1c;
+        --danger-soft: #fef2f2;
+        --shadow: 0 24px 64px rgba(15, 23, 42, 0.12), 0 4px 14px rgba(15, 23, 42, 0.05);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei UI", sans-serif;
+      }
+
+      * { box-sizing: border-box; }
+
+      html, body { min-height: 100%; }
+
+      body {
+        margin: 0;
+        overflow-x: hidden;
+        background:
+          radial-gradient(circle at 14% 0%, rgba(37, 99, 235, 0.12), transparent 36%),
+          radial-gradient(circle at 92% 92%, rgba(13, 148, 136, 0.08), transparent 34%),
+          var(--bg);
+        color: var(--text);
+        -webkit-font-smoothing: antialiased;
+        text-rendering: optimizeLegibility;
+      }
+
+      body::before {
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        content: "";
+        opacity: 0.28;
+        background-image: linear-gradient(rgba(100, 116, 139, 0.06) 1px, transparent 1px), linear-gradient(90deg, rgba(100, 116, 139, 0.06) 1px, transparent 1px);
+        background-size: 34px 34px;
+        mask-image: linear-gradient(to bottom, black, transparent 68%);
+      }
+
+      .page-shell {
+        position: relative;
+        z-index: 1;
+        display: grid;
+        min-height: 100svh;
+        place-items: center;
+        padding: max(24px, env(safe-area-inset-top)) max(16px, env(safe-area-inset-right)) max(24px, env(safe-area-inset-bottom)) max(16px, env(safe-area-inset-left));
+      }
+
+      .connector-card {
+        width: min(100%, 440px);
+        overflow: hidden;
+        border: 1px solid var(--line);
+        border-radius: 24px;
+        background: var(--panel);
+        box-shadow: var(--shadow);
+        backdrop-filter: blur(18px);
+        animation: card-in 420ms cubic-bezier(0.22, 1, 0.36, 1) both;
+      }
+
+      .brand-bar {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 17px 20px;
+        border-bottom: 1px solid var(--line-soft);
+      }
+
+      .brand-bar img { width: 29px; height: 29px; object-fit: contain; }
+      .brand-name { font-size: 15px; font-weight: 800; letter-spacing: -0.01em; }
+      .brand-context { margin-left: auto; color: var(--muted); font-size: 12px; font-weight: 650; }
+
+      .card-body { padding: 27px 28px 28px; text-align: center; }
+
+      .passkey-visual {
+        position: relative;
+        display: grid;
+        width: 156px;
+        height: 156px;
+        margin: 0 auto 23px;
+        place-items: center;
+        border: 1px solid rgba(37, 99, 235, 0.13);
+        border-radius: 48px;
+        background: linear-gradient(145deg, #f8fbff 0%, #e7f0ff 100%);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9), 0 16px 34px rgba(37, 99, 235, 0.13);
+      }
+
+      .passkey-visual::before, .passkey-visual::after {
+        position: absolute;
+        border-radius: 999px;
+        content: "";
+      }
+
+      .passkey-visual::before { width: 9px; height: 9px; top: 21px; right: 28px; background: #14b8a6; box-shadow: 0 0 0 6px rgba(20, 184, 166, 0.10); }
+      .passkey-visual::after { width: 7px; height: 7px; bottom: 27px; left: 24px; background: #f59e0b; box-shadow: 0 0 0 5px rgba(245, 158, 11, 0.10); }
+      .passkey-visual svg { width: 106px; height: 106px; filter: drop-shadow(0 8px 12px rgba(30, 64, 175, 0.14)); }
+
+      .eyebrow {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        margin: 0 0 10px;
+        color: var(--primary);
+        font-size: 12px;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .eyebrow::before { width: 7px; height: 7px; border-radius: 50%; background: #14b8a6; box-shadow: 0 0 0 4px rgba(20, 184, 166, 0.11); content: ""; }
+
+      h1 { margin: 0; font-size: clamp(24px, 7vw, 30px); line-height: 1.18; letter-spacing: -0.035em; }
+      .intro { max-width: 340px; margin: 11px auto 0; color: var(--muted); font-size: 15px; line-height: 1.6; }
+
+      .status {
+        margin: 20px 0 0;
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 11px 12px;
+        background: var(--panel-soft);
+        color: var(--muted);
+        font-size: 13px;
+        font-weight: 650;
+        line-height: 1.45;
+      }
+
+      .status[hidden] { display: none; }
+      .status[data-kind="error"] { border-color: rgba(185, 28, 28, 0.19); background: var(--danger-soft); color: var(--danger); }
+      .status[data-kind="success"] { border-color: rgba(4, 120, 87, 0.19); background: var(--success-soft); color: var(--success); }
+
+      button {
+        position: relative;
+        display: inline-flex;
+        width: 100%;
+        min-height: 50px;
+        align-items: center;
+        justify-content: center;
+        margin-top: 20px;
+        overflow: hidden;
+        border: 1px solid transparent;
+        border-radius: 12px;
+        padding: 12px 18px;
+        background: linear-gradient(135deg, #2563eb 0%, #1e40af 100%);
+        box-shadow: 0 10px 22px rgba(37, 99, 235, 0.24);
+        color: #fff;
+        cursor: pointer;
+        font: inherit;
+        font-size: 15px;
+        font-weight: 800;
+        transition: transform 120ms ease, box-shadow 180ms ease, filter 180ms ease;
+        -webkit-tap-highlight-color: transparent;
+      }
+
+      button::after {
+        position: absolute;
+        width: 80px;
+        height: 160px;
+        left: -110px;
+        top: -55px;
+        background: rgba(255, 255, 255, 0.14);
+        content: "";
+        transform: rotate(22deg);
+        transition: left 360ms ease;
+      }
+
+      button:hover:not([data-state="waiting"]):not([data-state="unavailable"]) { filter: brightness(1.06); box-shadow: 0 13px 27px rgba(37, 99, 235, 0.29); }
+      button:hover::after { left: calc(100% + 30px); }
+      button:active:not([data-state="waiting"]):not([data-state="unavailable"]) { transform: translateY(1px); }
+      button:focus-visible { outline: 3px solid rgba(37, 99, 235, 0.22); outline-offset: 3px; }
+      button[data-state="waiting"], button[data-state="unavailable"] { cursor: default; opacity: 0.58; box-shadow: none; }
+      button[data-state="return"] { background: var(--panel-soft); border-color: var(--line); box-shadow: none; color: var(--primary); }
+
+      .security-note { display: inline-flex; align-items: center; gap: 6px; margin-top: 17px; color: var(--muted); font-size: 12px; font-weight: 650; }
+      .security-note svg { width: 14px; height: 14px; color: #0d9488; }
+
+      @keyframes card-in { from { opacity: 0; transform: translateY(12px) scale(0.985); } to { opacity: 1; transform: none; } }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0a0e13;
+          --panel: rgba(21, 27, 36, 0.96);
+          --panel-soft: #111720;
+          --line: rgba(148, 163, 184, 0.18);
+          --line-soft: rgba(148, 163, 184, 0.10);
+          --text: #f1f5f9;
+          --muted: #94a3b8;
+          --primary: #60a5fa;
+          --primary-soft: rgba(96, 165, 250, 0.12);
+          --success: #34d399;
+          --success-soft: rgba(52, 211, 153, 0.09);
+          --danger: #f87171;
+          --danger-soft: rgba(248, 113, 113, 0.09);
+          --shadow: 0 28px 70px rgba(0, 0, 0, 0.46);
+        }
+        body { background: radial-gradient(circle at 14% 0%, rgba(37, 99, 235, 0.16), transparent 38%), radial-gradient(circle at 92% 92%, rgba(20, 184, 166, 0.08), transparent 34%), var(--bg); }
+        .passkey-visual { border-color: rgba(96, 165, 250, 0.16); background: linear-gradient(145deg, #172235 0%, #111827 100%); box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05), 0 18px 38px rgba(0, 0, 0, 0.25); }
+      }
+
+      @media (max-width: 480px) {
+        .page-shell { align-items: center; padding-left: 12px; padding-right: 12px; }
+        .connector-card { border-radius: 20px; }
+        .brand-bar { padding: 15px 17px; }
+        .card-body { padding: 22px 20px 24px; }
+        .passkey-visual { width: 136px; height: 136px; margin-bottom: 20px; border-radius: 42px; }
+        .passkey-visual svg { width: 92px; height: 92px; }
+      }
+
+      @media (max-height: 650px) {
+        .card-body { padding-top: 20px; }
+        .passkey-visual { width: 112px; height: 112px; margin-bottom: 16px; border-radius: 35px; }
+        .passkey-visual svg { width: 78px; height: 78px; }
+        .intro { margin-top: 7px; }
+        button { margin-top: 16px; }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        *, *::before, *::after { animation-duration: 1ms !important; transition-duration: 1ms !important; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page-shell">
+      <section class="connector-card" aria-labelledby="webauthn-header">
+        <header class="brand-bar">
+          <img src="/nodewarden-logo.svg" alt="" />
+          <span class="brand-name">NodeWarden</span>
+          <span class="brand-context">WebAuthn</span>
+        </header>
+        <div class="card-body">
+          <div class="passkey-visual" aria-hidden="true">
+            <svg viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <rect x="22" y="15" width="76" height="90" rx="23" fill="#fff" stroke="#BFD3F7" stroke-width="3" />
+              <circle cx="60" cy="52" r="18" fill="#DBEAFE" stroke="#2563EB" stroke-width="3" />
+              <path d="M60 44a8 8 0 0 1 5.5 13.8V66h-11v-8.2A8 8 0 0 1 60 44Z" fill="#2563EB" />
+              <path d="M48 85h24" stroke="#94A3B8" stroke-width="4" stroke-linecap="round" />
+              <path d="M88 78h12a11 11 0 1 1 0 22H84" stroke="#0D9488" stroke-width="6" stroke-linecap="round" />
+              <path d="M84 89h22M99 89v7M91 89v5" stroke="#0D9488" stroke-width="6" stroke-linecap="round" />
+            </svg>
+          </div>
+          <p class="eyebrow">Secure sign-in</p>
+          <h1 id="webauthn-header">Two-step verification</h1>
+          <p id="webauthn-copy" class="intro">Use your passkey or security key to finish signing in.</p>
+          <div id="webauthn-status" class="status" role="status" aria-live="polite" hidden></div>
+          <button id="webauthn-button" type="button" data-state="loading" aria-busy="true">Preparing passkey…</button>
+          <div class="security-note">
+            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+              <path d="M7 10V8a5 5 0 0 1 10 0v2M6 10h12v10H6V10Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+              <path d="M12 14v2" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+            </svg>
+            <span id="secure-label">Protected by WebAuthn</span>
+          </div>
+        </div>
+      </section>
+    </main>
+    <script type="module" src="/webauthn-mobile-connector.js"></script>
+  </body>
+</html>

--- a/webapp/public/webauthn-mobile-connector.js
+++ b/webapp/public/webauthn-mobile-connector.js
@@ -1,0 +1,286 @@
+const CUSTOM_SCHEME_CALLBACK = 'bitwarden://webauthn-callback';
+const APP_LINK_HOSTS = ['bitwarden.com', 'bitwarden.eu', 'bitwarden.pw', 'bitwarden-gov.com'];
+
+function safeDecodeURIComponent(value) {
+  let decoded = String(value || '');
+  for (let index = 0; index < 2 && /%[0-9a-f]{2}/i.test(decoded); index += 1) {
+    try {
+      decoded = decodeURIComponent(decoded);
+    } catch (_error) {
+      break;
+    }
+  }
+  return decoded;
+}
+
+export function decodeBase64Utf8(value) {
+  let normalized = String(value || '').replace(/ /g, '+').replace(/-/g, '+').replace(/_/g, '/');
+  normalized += '='.repeat((4 - (normalized.length % 4 || 4)) % 4);
+  const binary = atob(normalized);
+  const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+  if (typeof TextDecoder !== 'undefined') {
+    return new TextDecoder().decode(bytes);
+  }
+  return decodeURIComponent(Array.from(bytes, (byte) => `%${byte.toString(16).padStart(2, '0')}`).join(''));
+}
+
+export function bytesFromBase64Url(value) {
+  let normalized = String(value || '').replace(/-/g, '+').replace(/_/g, '/');
+  normalized += '='.repeat((4 - (normalized.length % 4 || 4)) % 4);
+  return Uint8Array.from(atob(normalized), (character) => character.charCodeAt(0));
+}
+
+export function base64UrlFromBuffer(value) {
+  if (value == null) return undefined;
+  const bytes = value instanceof Uint8Array ? value : new Uint8Array(value);
+  let binary = '';
+  for (let index = 0; index < bytes.length; index += 1) {
+    binary += String.fromCharCode(bytes[index]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function appLinkHost(hostname) {
+  const normalized = String(hostname || '').toLowerCase();
+  return APP_LINK_HOSTS.find((host) => normalized === host || normalized.endsWith(`.${host}`)) || 'bitwarden.com';
+}
+
+/**
+ * Resolve only callback targets owned by the official mobile clients. The callbackUri
+ * inside V2 data is deliberately treated as a mobile-flow signal, never as a target.
+ */
+export function resolveMobileCallbackUri({ deeplinkScheme, payload, hostname, legacyMobile = false }) {
+  if (deeplinkScheme) {
+    return String(deeplinkScheme).toLowerCase() === 'https'
+      ? `https://${appLinkHost(hostname)}/webauthn-callback`
+      : CUSTOM_SCHEME_CALLBACK;
+  }
+  return payload?.mobile === true || payload?.callbackUri != null || legacyMobile
+    ? CUSTOM_SCHEME_CALLBACK
+    : null;
+}
+
+export function parseConnectorRequest(search, hostname = '') {
+  const params = search instanceof URLSearchParams
+    ? search
+    : new URLSearchParams(String(search || '').replace(/^\?/, ''));
+  const encodedData = params.get('data');
+  if (!encodedData) throw new Error('No WebAuthn challenge was provided.');
+
+  const version = params.get('v');
+  let payload = null;
+  let webauthnJson;
+  let headerText;
+  let buttonText;
+  let returnButtonText;
+  let awaitingText;
+
+  if (version === '1') {
+    webauthnJson = decodeBase64Utf8(encodedData);
+    headerText = params.get('headerText');
+    buttonText = params.get('btnText');
+    returnButtonText = params.get('btnReturnText');
+    awaitingText = params.get('btnAwaitingInteractionText');
+  } else {
+    try {
+      payload = JSON.parse(decodeBase64Utf8(encodedData));
+    } catch (_error) {
+      throw new Error('The WebAuthn challenge could not be decoded.');
+    }
+    if (!payload || (typeof payload.data !== 'string' && typeof payload.data !== 'object')) {
+      throw new Error('The WebAuthn challenge is incomplete.');
+    }
+    webauthnJson = typeof payload.data === 'string' ? payload.data : JSON.stringify(payload.data);
+    headerText = payload.headerText;
+    buttonText = payload.btnText;
+    returnButtonText = payload.btnReturnText;
+    awaitingText = payload.btnAwaitingInteractionText;
+  }
+
+  const callbackUri = resolveMobileCallbackUri({
+    deeplinkScheme: params.get('deeplinkScheme'),
+    payload,
+    hostname,
+    legacyMobile: params.get('client') === 'mobile',
+  });
+  if (!callbackUri) throw new Error('No supported mobile return target was provided.');
+
+  return {
+    callbackUri,
+    webauthnJson,
+    headerText: safeDecodeURIComponent(headerText),
+    buttonText: safeDecodeURIComponent(buttonText),
+    returnButtonText: safeDecodeURIComponent(returnButtonText),
+    awaitingText: safeDecodeURIComponent(awaitingText),
+  };
+}
+
+export function normalizePublicKeyOptions(webauthnJson) {
+  const source = typeof webauthnJson === 'string' ? JSON.parse(webauthnJson) : webauthnJson;
+  if (!source || typeof source !== 'object' || !source.challenge) {
+    throw new Error('The WebAuthn challenge is invalid.');
+  }
+  const publicKey = { ...source, challenge: bytesFromBase64Url(source.challenge) };
+  if (Array.isArray(source.allowCredentials)) {
+    publicKey.allowCredentials = source.allowCredentials.map((credential) => ({
+      ...credential,
+      id: bytesFromBase64Url(credential?.id),
+    }));
+  }
+  return publicKey;
+}
+
+export function buildCredentialData(assertedCredential) {
+  const response = assertedCredential?.response;
+  if (!assertedCredential || !response?.authenticatorData || !response?.clientDataJSON || !response?.signature) {
+    throw new Error('The authenticator returned an incomplete response.');
+  }
+  return JSON.stringify({
+    id: assertedCredential.id,
+    rawId: base64UrlFromBuffer(assertedCredential.rawId),
+    type: assertedCredential.type,
+    extensions: typeof assertedCredential.getClientExtensionResults === 'function'
+      ? assertedCredential.getClientExtensionResults()
+      : {},
+    response: {
+      authenticatorData: base64UrlFromBuffer(response.authenticatorData),
+      clientDataJson: base64UrlFromBuffer(response.clientDataJSON),
+      signature: base64UrlFromBuffer(response.signature),
+    },
+  });
+}
+
+export function buildCallbackUrl(callbackUri, key, value) {
+  const separator = String(callbackUri).includes('?') ? '&' : '?';
+  return `${callbackUri}${separator}${encodeURIComponent(key)}=${encodeURIComponent(String(value || ''))}`;
+}
+
+function translations(locale) {
+  const normalized = String(locale || 'en').toLowerCase();
+  if (normalized.startsWith('zh-tw') || normalized.startsWith('zh-hk')) {
+    return {
+      title: '兩步驟驗證',
+      copy: '使用通行密鑰或安全金鑰完成登入。',
+      button: '使用通行密鑰驗證',
+      awaiting: '請依照系統提示完成驗證…',
+      returning: '正在返回 Bitwarden…',
+      returnButton: '返回 Bitwarden',
+      secure: '由 WebAuthn 安全保護',
+      unsupported: '此瀏覽器不支援通行密鑰。',
+      cancelled: '驗證已取消，請重試。',
+    };
+  }
+  if (normalized.startsWith('zh')) {
+    return {
+      title: '两步验证',
+      copy: '使用通行密钥或安全密钥完成登录。',
+      button: '使用通行密钥验证',
+      awaiting: '请按照系统提示完成验证…',
+      returning: '正在返回 Bitwarden…',
+      returnButton: '返回 Bitwarden',
+      secure: '由 WebAuthn 安全保护',
+      unsupported: '此浏览器不支持通行密钥。',
+      cancelled: '验证已取消，请重试。',
+    };
+  }
+  return {
+    title: 'Two-step verification',
+    copy: 'Use your passkey or security key to finish signing in.',
+    button: 'Authenticate with passkey',
+    awaiting: 'Follow the system prompt to continue…',
+    returning: 'Returning to Bitwarden…',
+    returnButton: 'Return to Bitwarden',
+    secure: 'Protected by WebAuthn',
+    unsupported: 'This browser does not support passkeys.',
+    cancelled: 'Verification was cancelled. Please try again.',
+  };
+}
+
+function browserErrorMessage(error, text) {
+  if (error?.name === 'NotAllowedError' || error?.name === 'AbortError') return text.cancelled;
+  return error?.message || String(error || 'WebAuthn failed.');
+}
+
+function initializePage() {
+  const button = document.getElementById('webauthn-button');
+  const header = document.getElementById('webauthn-header');
+  const copy = document.getElementById('webauthn-copy');
+  const status = document.getElementById('webauthn-status');
+  const secureLabel = document.getElementById('secure-label');
+  if (!button || !header || !copy || !status || !secureLabel) return;
+
+  const text = translations(navigator.languages?.[0] || navigator.language);
+  document.documentElement.lang = navigator.languages?.[0] || navigator.language || 'en';
+  copy.textContent = text.copy;
+  secureLabel.textContent = text.secure;
+
+  let request;
+  let publicKey;
+  let sent = false;
+  let returnUri = '';
+
+  function setButton(label, state, handler) {
+    button.textContent = label;
+    button.dataset.state = state;
+    button.setAttribute('aria-busy', state === 'waiting' ? 'true' : 'false');
+    button.onclick = handler;
+  }
+
+  function setStatus(kind, message) {
+    status.hidden = !message;
+    status.dataset.kind = kind;
+    status.textContent = message || '';
+  }
+
+  function navigate(uri) {
+    returnUri = uri;
+    window.location.replace(uri);
+    setButton(request?.returnButtonText || text.returnButton, 'return', () => window.location.replace(returnUri));
+  }
+
+  function handoffError(message) {
+    setStatus('error', message);
+    if (request?.callbackUri) navigate(buildCallbackUrl(request.callbackUri, 'error', message));
+  }
+
+  async function executeWebAuthn() {
+    if (sent || button.dataset.state === 'waiting') return;
+    setStatus('info', request.awaitingText || text.awaiting);
+    setButton(request.awaitingText || text.awaiting, 'waiting', null);
+    try {
+      const credential = await navigator.credentials.get({ publicKey });
+      if (!credential) throw new Error('No passkey was selected.');
+      const data = buildCredentialData(credential);
+      sent = true;
+      setStatus('success', text.returning);
+      navigate(buildCallbackUrl(request.callbackUri, 'data', data));
+    } catch (error) {
+      setButton(request.buttonText || text.button, 'ready', executeWebAuthn);
+      handoffError(browserErrorMessage(error, text));
+    }
+  }
+
+  try {
+    request = parseConnectorRequest(window.location.search, window.location.hostname);
+    publicKey = normalizePublicKeyOptions(request.webauthnJson);
+    header.textContent = request.headerText || text.title;
+    setButton(request.buttonText || text.button, 'ready', executeWebAuthn);
+  } catch (error) {
+    header.textContent = text.title;
+    setStatus('error', browserErrorMessage(error, text));
+    setButton(text.button, 'unavailable', null);
+  }
+
+  if (!navigator.credentials || typeof navigator.credentials.get !== 'function' || !window.PublicKeyCredential) {
+    handoffError(text.unsupported);
+    if (!request?.callbackUri) setButton(text.button, 'unavailable', null);
+  }
+}
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializePage, { once: true });
+  } else {
+    initializePage();
+  }
+}

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -145,6 +145,14 @@ self.addEventListener('fetch', (event) => {
   const url = new URL(request.url);
   if (NEVER_CACHE_PATH_RE.test(url.pathname)) return;
 
+  // 真实的 connector 页面（webauthn-fallback-connector.html /
+  // webauthn-mobile-connector.html / sso-connector.html 等）必须原样返回，
+  // 不能被 app shell 回退吞掉。网络优先，离线时才退回 shell。
+  if (url.pathname.endsWith('-connector.html')) {
+    event.respondWith(fetch(request).catch(() => appShellNavigation(request)));
+    return;
+  }
+
   if (request.mode === 'navigate') {
     event.respondWith(appShellNavigation(request));
     if (navigator.onLine !== false) {


### PR DESCRIPTION
## Summary

Fixes #326.

Bitwarden mobile clients use `/webauthn-mobile-connector.html` to complete WebAuthn two-step authentication. When this page is unavailable, the PWA fallback may return the main SPA shell, preventing the WebAuthn flow from starting.

This pull request:

- Adds a mobile WebAuthn connector compatible with Bitwarden iOS and Android.
- Returns successful assertions and errors through the expected mobile callback/deeplink.
- Prevents arbitrary callback URL injection by restricting redirects to supported Bitwarden callback targets.
- Makes the Service Worker fetch `*-connector.html` pages directly instead of serving the cached SPA shell.
- Adds protocol and HTML contract tests for the connector.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor

## Implementation Details

### WebAuthn Mobile Connector

Added:

- `webapp/public/webauthn-mobile-connector.html`
- `webapp/public/webauthn-mobile-connector.js`

The connector supports:

- Bitwarden iOS V2 connector payloads.
- Android custom-scheme and HTTPS App Link callbacks.
- Legacy mobile connector markers.
- WebAuthn challenge and credential Base64URL conversion.
- Successful callbacks using `?data=...`.
- Error callbacks using `?error=...`.
- A fallback “Return to Bitwarden” button when automatic navigation is blocked.
- Responsive layout, accessibility, dark mode, mobile safe-area support, and a restrictive Content Security Policy.

Client-provided `callbackUri` values are used only to identify a mobile flow. They are never accepted as arbitrary redirect destinations.

### PWA Connector Handling

Updated the generated Service Worker so requests ending in `-connector.html` use a network-first path, including:

- `/webauthn-mobile-connector.html`
- `/webauthn-fallback-connector.html`
- `/sso-connector.html`

This prevents connector requests from being replaced by the cached SPA shell.

### Automated Tests

Added `scripts/webauthn-mobile-connector.test.mjs`, covering:

- iOS V2 payload parsing.
- Android deeplink and App Link callbacks.
- Callback injection prevention.
- Legacy mobile compatibility.
- UTF-8 and Base64URL decoding.
- Public-key option normalization.
- Credential serialization.
- Success and error callback encoding.
- Connector HTML contract validation.

A new npm command is available:

```shell
npm run test:webauthn-mobile