### PR TITLE
feat: add password field to vault search index

### DIFF
--- a/webapp/src/components/VaultPage.tsx
+++ b/webapp/src/components/VaultPage.tsx
@@ -1,4 +1,4 @@
-﻿import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import LoadingState from '@/components/LoadingState';
 import VaultDialogs from '@/components/vault/VaultDialogs';
 import VaultDetailView from '@/components/vault/VaultDetailView';
@@ -313,6 +313,7 @@ export default function VaultPage(props: VaultPageProps) {
       const username = String(cipher.login?.decUsername || '');
       const uri = firstCipherUri(cipher);
       const typedText = [
+        cipher.login?.decPassword,
         cipher.bankAccount?.decBankName,
         cipher.bankAccount?.decNameOnAccount,
         cipher.bankAccount?.decAccountNumber,


### PR DESCRIPTION
## Summary
Closes https://github.com/shuaiplus/nodewarden/issues/330

在密码库搜索索引中新增密码字段，使用户可以通过搜索密码内容来定位对应的条目。
## Change Type
- [ ] Bug fix
- [x] Feature
- [ ] Compatibility update
- [ ] Documentation
- [ ] Refactor
## Cross-File Checklist
- [x] I read `CONTRIBUTING.md`.
- [ ] Schema changes, if any, updated both runtime schema and `migrations/0001_init.sql`.
- [ ] Persistent data changes, if any, updated backup export/import or documented why backup is not needed.
- [ ] User-facing text changes, if any, updated all locale files.
- [ ] Bitwarden client compatibility was considered for sync/API shape changes.
- [x] No secrets, tokens, private deployment values, or real vault data are included.
## Checks
- [x] `npx tsc -p tsconfig.json --noEmit`
- [x] `npx tsc -p webapp/tsconfig.json --noEmit`
- [ ] `npm run i18n:validate`
- [x] `npm run build`
## Notes
仅修改 `webapp/src/components/VaultPage.tsx` 一个文件，在 `cipherMetaById` 构建搜索文本时将 `cipher.login?.decPassword` 加入 `typedText` 数组。搜索逻辑本身无需改动，因为 `searchText` 已通过 `includes()` 进行子串匹配。


## 目前能搜索的字段情况

| 类型 | 字段 | 说明 | 可搜索 |
|------|------|------|--------|
| 通用 | `cipherId` | Cipher ID（含连字符） | ✅ |
| 通用 | `cipherId` | Cipher ID（不含连字符） | ✅ |
| 通用 | `decName` | 项目名称 | ✅ |
| 登录 | `decUsername` | 用户名 | ✅ |
| 登录 | `decUri` | 网站 URI（第一个） | ✅ |
| 登录 | `decPassword` | 密码 | ✅ |
| 银行账户 | `decBankName` | 银行名称 | ✅ |
| 银行账户 | `decNameOnAccount` | 户名 | ✅ |
| 银行账户 | `decAccountNumber` | 账号 | ✅ |
| 驾照 | `decLicenseNumber` | 驾照号 | ✅ |
| 驾照 | `decFirstName` | 名 | ✅ |
| 驾照 | `decLastName` | 姓 | ✅ |
| 护照 | `decPassportNumber` | 护照号 | ✅ |
| 护照 | `decGivenName` | 名 | ✅ |
| 护照 | `decSurname` | 姓 | ✅ |
| 登录 | `decNotes` | 备注 | ❌ |
| 登录 | `decTotp` | TOTP | ❌ |
| 身份证 | 所有字段 | 姓名、邮箱、电话、公司、地址等 | ❌ |
| 信用卡 | 所有字段 | 持卡人、卡号、品牌、有效期、CVV | ❌ |
| SSH 密钥 | 所有字段 | 私钥、公钥、指纹 | ❌ |
| 自定义 | 所有字段 | 字段名和值 | ❌ |