### PR TITLE
fix: resolve PostCSS OSV vulnerability

### DIFF
--- a/.github/workflows/security-extra.yml
+++ b/.github/workflows/security-extra.yml
@@ -48,8 +48,8 @@ jobs:
       upload-sarif: true
       fail-on-vuln: true
 
-  pnpm-audit:
-    name: pnpm audit
+  npm-audit:
+    name: npm audit
     runs-on: ubuntu-latest
 
     permissions:
@@ -66,17 +66,8 @@ jobs:
         with:
           node-version: 22
 
-      - name: Run pnpm audit
-        shell: bash
-        run: |
-          if [ ! -f pnpm-lock.yaml ]; then
-            echo "pnpm-lock.yaml not found, skip pnpm audit."
-            exit 0
-          fi
-
-          corepack enable
-          corepack prepare pnpm@10 --activate
-          pnpm audit --audit-level=high
+      - name: Run npm audit
+        run: npm audit --audit-level=high
 
   semgrep:
     name: Semgrep CE Scan

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@types/node": "^26.0.1",
         "autoprefixer": "^10.5.2",
         "opencc-js": "^1.3.2",
-        "postcss": "^8.5.16",
+        "postcss": "^8.5.18",
         "tailwindcss": "^3.4.19",
         "tsx": "^4.22.4",
         "typescript": "^6.0.3",
@@ -3904,9 +3904,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4069,9 +4069,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -4089,7 +4089,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^26.0.1",
     "autoprefixer": "^10.5.2",
     "opencc-js": "^1.3.2",
-    "postcss": "^8.5.16",
+    "postcss": "^8.5.18",
     "tailwindcss": "^3.4.19",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",


### PR DESCRIPTION
## Summary

- Raise the declared PostCSS version from `^8.5.16` to the patched `^8.5.18` range for [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849).
- Refresh `package-lock.json`, resolving PostCSS to `8.5.23` and its required Nano ID dependency to `3.3.16`.
- Replace the `pnpm audit` job—which always skipped because this repository has no `pnpm-lock.yaml`—with `npm audit --audit-level=high` against the existing npm lockfile.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Compatibility update
- [ ] Documentation
- [ ] Refactor

## Cross-File Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] Schema changes, if any, updated both runtime schema and `migrations/0001_init.sql` (no schema changes).
- [x] Persistent data changes, if any, updated backup export/import or documented why backup is not needed (no persistent data changes).
- [x] User-facing text changes, if any, updated all locale files (no user-facing text changes).
- [x] Bitwarden client compatibility was considered for sync/API shape changes (no sync/API shape changes).
- [x] No secrets, tokens, private deployment values, or real vault data are included.

## Checks

- [x] `npx tsc -p tsconfig.json --noEmit`
- [ ] `npx tsc -p webapp/tsconfig.json --noEmit` (fails with the same four pre-existing errors on base commit `8e5d9e2`; see Notes)
- [x] `npm run i18n:validate`
- [x] `npm run build`
- [x] `npm audit --audit-level=high` (`0` vulnerabilities)
- [x] OSV, CodeQL, Semgrep, Gitleaks, actionlint, and zizmor workflows pass on the head commit.

## Notes

The webapp TypeScript check fails identically on both this branch and the base commit in the following unchanged files:

- `webapp/src/lib/api/backup.ts`
- `webapp/src/lib/backup-center.ts`
- `webapp/src/lib/password-security-cache.ts`
- `webapp/vite.config.ts`

This PR changes only dependency metadata and the matching dependency-audit workflow; it does not modify runtime or webapp source code.