### PR TITLE
fix(styles): use theme tokens for hardcoded brand blues

### DIFF
--- a/webapp/src/styles/auth.css
+++ b/webapp/src/styles/auth.css
@@ -369,7 +369,7 @@
 .not-found-code {
   @apply rounded-full px-3 py-1 text-sm font-extrabold;
   background: #eef4ff;
-  color: #1d4ed8;
+  color: var(--primary-hover);
 }
 
 .not-found-copy {
@@ -574,7 +574,7 @@
 
 .jwt-inline-link {
   @apply font-bold no-underline;
-  color: #1d4ed8;
+  color: var(--primary-hover);
 }
 
 .jwt-inline-link:hover {
@@ -613,7 +613,7 @@
 
 .standalone-footer a {
   @apply font-bold no-underline;
-  color: #1d4ed8;
+  color: var(--primary-hover);
 }
 
 .standalone-footer a:hover {
@@ -622,5 +622,5 @@
 
 .standalone-version {
   @apply font-bold;
-  color: #1d4ed8;
+  color: var(--primary-hover);
 }

--- a/webapp/src/styles/dark.css
+++ b/webapp/src/styles/dark.css
@@ -220,7 +220,7 @@
 }
 
 :root[data-theme='dark'] .card-brand-icon {
-  color: #bfdbfe;
+  color: var(--primary-strong);
   background: linear-gradient(180deg, #1f2937 0%, #111827 100%);
   border-color: color-mix(in srgb, var(--primary) 30%, var(--line));
 }

--- a/webapp/src/styles/management.css
+++ b/webapp/src/styles/management.css
@@ -99,7 +99,7 @@
   @apply inline-flex h-[22px] w-[22px] shrink-0 cursor-pointer items-center justify-center rounded-full p-0 text-[13px] font-extrabold leading-none;
   border: 1px solid #bfd1f3;
   background: #eef4ff;
-  color: #1d4ed8;
+  color: var(--primary-hover);
 }
 
 .backup-help-trigger:hover,
@@ -194,7 +194,7 @@
 }
 
 .backup-recommendation-step a {
-  color: #1d4ed8;
+  color: var(--primary-hover);
   font-weight: 700;
   text-decoration: underline;
   text-underline-offset: 2px;
@@ -316,14 +316,14 @@
 }
 
 .backup-interval-preset:hover:not(:disabled) {
-  border-color: #2563eb;
-  color: #2563eb;
+  border-color: var(--primary);
+  color: var(--primary);
   background: #eff6ff;
 }
 
 .backup-interval-preset.active {
-  border-color: #2563eb;
-  background: #2563eb;
+  border-color: var(--primary);
+  background: var(--primary);
   color: #fff;
 }
 
@@ -1786,7 +1786,7 @@
 }
 
 .restore-progress-item.active {
-  color: #1d4ed8;
+  color: var(--primary-hover);
 }
 
 .restore-progress-item.done {
@@ -1799,7 +1799,7 @@
 }
 
 .restore-progress-item.active .restore-progress-dot {
-  background: #1d4ed8;
+  background: var(--primary-hover);
 }
 
 .restore-progress-item.done .restore-progress-dot {
@@ -1871,7 +1871,7 @@
 .authorized-device-checkbox {
   width: 16px;
   height: 16px;
-  accent-color: #2563eb;
+  accent-color: var(--primary);
 }
 
 .authorized-devices-table td:first-child {

--- a/webapp/src/styles/vault.css
+++ b/webapp/src/styles/vault.css
@@ -47,7 +47,7 @@
 }
 
 .folder-add-btn:hover {
-  color: #1d4ed8;
+  color: var(--primary-hover);
 }
 
 .search-input {
@@ -161,7 +161,7 @@
 }
 
 .folder-sort-btn:hover {
-  color: #1d4ed8;
+  color: var(--primary-hover);
   background: #dbeafe;
   transform: scale(1.06);
 }
@@ -962,7 +962,7 @@ select.input.duplicate-mode-toolbar-select {
 }
 
 .totp-ring-progress {
-  stroke: #2563eb;
+  stroke: var(--primary);
   stroke-linecap: round;
   transition: stroke-dashoffset 260ms linear, stroke 200ms ease;
 }


### PR DESCRIPTION
## Summary

Several stylesheets hardcode the brand blues (`#1d4ed8`, `#2563eb`, `#bfdbfe`) instead of using the design tokens from `tokens.css`. In dark mode, the spots that `dark.css` never overrides keep their light-theme blue on dark backgrounds — most visibly the standalone footer links and version badge on the login page, the JWT warning inline link, the TOTP countdown ring, the restore-progress active dot, and the authorized-device checkbox.

This PR replaces 17 declarations with their exact token equivalents (`var(--primary)`, `var(--primary-hover)`, `var(--primary-strong)`).

## Safety

Every replaced hex is byte-identical to the token's light value, so **light theme rendering is unchanged**. I verified this at runtime by asserting `getComputedStyle` on each affected selector in light mode — all resolve to the same rgb values as before.

In dark mode, selectors that `dark.css` already overrides are also unchanged (the overrides win on specificity). Only the never-overridden spots change, from light-theme blue to the dark token values (e.g. the login footer links and TOTP countdown ring become the dark-theme blues).

Deliberately **not** changed, to avoid regressions:
- `.btn-primary` gradients — tokenizing would put dark-theme `--primary` (#60a5fa) under white text; and the hover stop `#1e3a8a` has no token.
- Card brand colors (`.card-brand-american-express`, `.card-brand-maestro`, `.card-brand-rupay`) — these are brand constants, not theme colors.
- Light-pill pairings whose backgrounds are hardcoded with no matching token (`.log-mode-option.active`, `.log-category-auth`, `.log-level-info`, `.folder-edit-btn:hover`) — tokenizing only the foreground would hurt contrast in dark mode; these need a paired treatment in a follow-up.
- `#93c5fd` borders (`.backup-destination-item:hover`, `.log-row:hover`) — no exact token exists.

## Test plan
- [x] `npm run build` passes
- [x] Light mode: computed colors on all changed selectors identical to before (runtime-verified)
- [x] Dark mode: changed spots resolve to `--primary`/`--primary-hover`/`--primary-strong` dark values; overridden spots unchanged
- [x] Visual pass over login/404, Verification Code, Cloud Backup, and vault pages in both themes
