### PR TITLE
fix(vault): stop detail-row value column collapsing to zero width

### DIFF
--- a/webapp/src/styles/vault.css
+++ b/webapp/src/styles/vault.css
@@ -860,7 +860,9 @@ select.input.duplicate-mode-toolbar-select {
 
 .kv-row {
   @apply grid items-center gap-2.5 py-2.5;
-  grid-template-columns: minmax(0px, 80px) minmax(0, 1fr) auto;
+  /* Floor the value column so the auto-sized actions column wraps its
+     buttons instead of collapsing the value to 0 width. */
+  grid-template-columns: minmax(0px, 80px) minmax(min(35%, 140px), 1fr) auto;
   border-bottom: 1px solid rgba(154, 172, 205, 0.22);
 }
 


### PR DESCRIPTION
## Summary

Since the Password Security feature added the **Check breach** button (99b5027), the vault detail's password row can render its masked value as a vertical column of one asterisk per line at common desktop widths.

**Root cause:** `.kv-row` uses `grid-template-columns: minmax(0px, 80px) minmax(0, 1fr) auto`. The `auto` actions column claims its content width before the `minmax(0, 1fr)` value column, so once label + three buttons exceed the row width the value column resolves to `0px` — measured live as `80px 0px 310.99px` at a 1512px window. With `overflow-wrap: anywhere` on `.kv-main > strong`, the 24-character mask then stacks one character per line.

**Fix (one line):** give the value column a floor — `minmax(min(35%, 140px), 1fr)`. The actions column now shrinks first, and since `.kv-actions` already has `flex-wrap: wrap`, its buttons wrap to a second line gracefully. No visual change at widths where the row already fit.

## Verified
- Default 1512px window, login item: mask renders horizontally (grid resolves to `80px 140px 217px`); Check breach wraps below Reveal/Copy
- Narrow window (~1180px): still horizontal, buttons wrap cleanly
- Light and dark themes; masked and revealed states (revealed long passwords wrap readably)
- Username / TOTP / Website rows unchanged (their value columns were already ≥140px)
- `npm run build` passes