### PR TITLE
fix(devices): wrap authorized-device action buttons instead of clipping

### DIFF
--- a/webapp/src/styles/management.css
+++ b/webapp/src/styles/management.css
@@ -1879,7 +1879,9 @@
 }
 
 .authorized-devices-actions {
-  flex-wrap: nowrap;
+  /* Wrap instead of clipping: four non-shrinking buttons overflow the
+     fixed 26% actions column at common widths, hiding Delete entirely. */
+  flex-wrap: wrap;
   gap: 6px;
 }
 


### PR DESCRIPTION
## Summary

On the Device Management page, the Authorized Devices table clips its action buttons at common desktop widths: **Device note** gets cut mid-label and **Delete** is pushed entirely off-canvas — unreachable.

**Root cause:** `.authorized-devices-actions` sets `flex-wrap: nowrap` while each `.btn.small` inside it has `flex: 0 0 auto; white-space: nowrap`, so the four buttons (Untrust, Trust permanently, Device note, Delete) can neither wrap nor shrink. The table uses `table-layout: fixed` with the actions column at 26%, and fixed layout clips any cell content wider than its column. Four labeled buttons need ~450-500px, which 26% only provides on very wide viewports.

**Fix (one line):** `flex-wrap: nowrap` → `wrap`. When the column is tight the buttons flow onto a second line (the row grows slightly taller); nothing is ever hidden. Wide viewports where one line already fit are unchanged.

## Verified
- ~1500px and ~1150px viewports: all four buttons visible, wrapping 2+2; disabled states (untrusted device) render correctly
- Light and dark themes
- `npm run build` passes