### PR TITLE
fix(vault): let the list toolbar wrap instead of overflowing

### DIFF
--- a/webapp/src/styles/vault.css
+++ b/webapp/src/styles/vault.css
@@ -230,7 +230,7 @@ select.input.duplicate-mode-toolbar-select {
 }
 
 .list-head {
-  @apply mb-1.5 flex items-center gap-2;
+  @apply mb-1.5 flex flex-wrap items-center gap-2;
   min-height: 34px;
 }
 


### PR DESCRIPTION
## Summary

In the Duplicates view, the list toolbar overflows its column at every desktop width: the search input truncates, the detection-mode select crushes to a sliver, and the Sync Vault / Select Duplicates buttons overlap and spill past the column edge.

**Root cause:** `.list-head` is a single-line flex row (`flex items-center`, no wrap) whose buttons are `whitespace-nowrap` and therefore cannot shrink below their labels. The duplicates view adds two controls (mode select + Select-duplicates button) to the standard search/Sort/Sync set, and `.list-col` caps the column at `max-w-[540px]` on desktop — so the combined controls always exceed the available width. The flexible items (search, mode select) compress to their floor first, then the fixed buttons overlap.

**Fix (one line):** add `flex-wrap` to `.list-head`. Views whose controls fit keep their exact single-line layout (verified: standard All Items toolbar renders at the same 34px height, children within 1px). Crowded toolbars flow onto a second row with full-width search and readable labels. Mobile is unaffected — the responsive breakpoint switches `.list-head` to its own grid display.

## Verified
- Duplicates view: two clean rows, all controls fully labeled and clickable, no overlap
- All Items view: pixel-identical single line (34px head height measured before/after)
- Light and dark themes; `npm run build` passes