### PR TITLE
fix(vault): keep duplicate group indices unique when selecting duplicates

### DIFF
--- a/webapp/src/components/VaultPage.tsx
+++ b/webapp/src/components/VaultPage.tsx
@@ -382,7 +382,9 @@ export default function VaultPage(props: VaultPageProps) {
     }
     const groupIndexByKey = new Map<string, number>();
     Array.from(groupKeys).sort().forEach((groupKey, index) => {
-      groupIndexByKey.set(groupKey, index % 64);
+      // Keep indices unique (no modulo): they are used both for group colors and
+      // as the group identity when selecting duplicate items to delete.
+      groupIndexByKey.set(groupKey, index);
     });
     const byId = new Map<string, number>();
     for (const [cipherId, groupKey] of groupKeyById.entries()) {


### PR DESCRIPTION
## Summary

修复 #350。

在密码库「重复项」视图里，“选择重复项”本应让每个重复组**保留一条**不勾选、其余全部勾选以便删除。但当密码库里的重复组超过 64 个时，靠后的重复组会被**整组全选**，用户只能手动挨个取消，体验很差。

**根因：** `duplicateGroupIndexById` 用 `index % 64` 截断了每个重复组的编号（本意是限制配色槽数量），而同一个编号又被 `handleSelectUniqueFromDuplicates` 当作组的唯一身份（`Set<number>`）来判断“该组是否已保留一条”。重复组超过 64 个后编号循环复用，算法遇到后续某个组的第一条时误以为“该组已保留过”，于是把这一整组全部勾选。

**修复（一行）：** 不再截断编号 —— `groupIndexByKey.set(groupKey, index)`。编号保持唯一（0..N-1）。配色不受影响：组的色相由黄金角 `index * 137.508 % 360` 推导，本身就能得到不同色相，去掉取模反而让第 64 组之后的组不再与前面的组撞色。

**用户可见变化：** 当重复组很多时，“选择重复项”现在能精确地为每组保留一条（此前靠后的组会被整组选中）。

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Compatibility update
- [ ] Documentation
- [ ] Refactor

## Cross-File Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] Schema changes, if any, updated both runtime schema and `migrations/0001_init.sql`. — 不适用，无 schema 变更。
- [x] Persistent data changes, if any, updated backup export/import or documented why backup is not needed. — 不适用，无持久化数据变更。
- [x] User-facing text changes, if any, updated all locale files. — 不适用，无用户可见文案变更。
- [x] Bitwarden client compatibility was considered for sync/API shape changes. — 不适用，纯前端改动，无 sync/API 结构变化。
- [x] No secrets, tokens, private deployment values, or real vault data are included.

## Checks

- [x] `npx tsc -p tsconfig.json --noEmit`
- [x] `npx tsc -p webapp/tsconfig.json --noEmit` — 改动文件通过；仅剩 3 个在 `main` 上就存在的预存错误，且都位于无关文件（`webapp/src/lib/api/backup.ts`、`webapp/src/lib/backup-center.ts`、`webapp/src/lib/password-security-cache.ts`）。
- [x] `npm run i18n:validate`
- [x] `npm run build`

## Notes

- 仅修改 `webapp/src/components/VaultPage.tsx` 一个文件（1 行逻辑 + 说明注释）。
- 通过模拟验证：70 个重复组 × 每组 3 条 → 修复前选中 146 条（复现 bug），修复后选中 140 条（每组恰好保留 1 条）。
- 该编号同时用于每组配色；去掉 `% 64` 后第 64 组起的组不再与前面组共用同一色相。