### PR TITLE
fix: 服务端密码哈希使用随机 per-user salt 替代邮箱作为 salt

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -8,6 +8,11 @@ import { StorageService } from './storage';
 // This second layer only needs to be non-trivial, not expensive.
 const SERVER_HASH_ITERATIONS = 100_000;
 const SERVER_HASH_PREFIX = '$s$';
+// Per-user random salt for server-side hashing.
+// 128 bits of entropy satisfies OWASP Password Storage Cheat Sheet.
+const SERVER_SALT_BYTES = 16;
+// 16 bytes → 24 base64 characters (with padding).
+const SERVER_SALT_BASE64_LENGTH = 24;
 const AUTH_CONTEXT_CACHE_TTL_MS = 15 * 1000;
 
 interface CachedUserEntry {
@@ -134,10 +139,64 @@ export class AuthService {
     return device;
   }
 
-  // Second-layer hash: PBKDF2-SHA256(clientHash, email-salt, iterations).
-  // Ensures database contents alone cannot be used to authenticate (pass-the-hash defense).
-  // Result is prefixed to distinguish server-hashed credentials from invalid legacy rows.
-  async hashPasswordServer(clientHash: string, email: string): Promise<string> {
+  // Second-layer hash: PBKDF2-SHA256(clientHash, random-per-user-salt, 100k).
+  // Self-describing format: $s$<salt_b64>$<hash_b64>
+  //
+  // Per-user random salt eliminates two attack vectors:
+  //   1. Cross-instance correlation (same email → same hash across deployments)
+  //   2. Precomputed rainbow tables (every user now has a unique salt)
+  //
+  // Legacy format (pre-salt): $s$<hash_b64> — verified via email-derived salt
+  // for backward compatibility. Users are auto-upgraded on next password change.
+  //
+  // The `_email` parameter is retained for API compatibility but unused in the
+  // new path. It is still needed for legacy-format verification.
+  async hashPasswordServer(clientHash: string, _email: string): Promise<string> {
+    const salt = crypto.getRandomValues(new Uint8Array(SERVER_SALT_BYTES));
+    const hash = await this.deriveServerHash(clientHash, salt);
+    return `${SERVER_HASH_PREFIX}${this.bytesToBase64(salt)}$${hash}`;
+  }
+
+  // Verify password: dispatches by stored format.
+  //   - No prefix     → legacy raw client hash
+  //   - $s$<h>        → legacy server hash with email-derived salt
+  //   - $s$<s>$<h>    → new server hash with embedded random salt
+  async verifyPassword(inputHash: string, storedHash: string, email: string): Promise<boolean> {
+    if (!storedHash.startsWith(SERVER_HASH_PREFIX)) {
+      return this.constantTimeEquals(inputHash, storedHash);
+    }
+
+    const payload = storedHash.substring(SERVER_HASH_PREFIX.length);
+    const parts = payload.split('$');
+
+    // New format: $s$<salt_b64>$<hash_b64>
+    if (parts.length === 2) {
+      const [saltB64, expectedHash] = parts;
+      if (
+        saltB64 &&
+        expectedHash &&
+        saltB64.length === SERVER_SALT_BASE64_LENGTH
+      ) {
+        try {
+          const salt = this.base64ToBytes(saltB64);
+          if (salt.length === SERVER_SALT_BYTES) {
+            const computedHash = await this.deriveServerHash(inputHash, salt);
+            return this.constantTimeEquals(computedHash, expectedHash);
+          }
+        } catch {
+          // Malformed base64 — fall through to legacy verification (returns false).
+        }
+      }
+    }
+
+    // Legacy format: $s$<hash_b64> — use email-derived salt to recompute.
+    const legacySalt = new TextEncoder().encode(email.toLowerCase().trim());
+    const legacyHash = await this.deriveServerHash(inputHash, legacySalt);
+    return this.constantTimeEquals(legacyHash, payload);
+  }
+
+  // Shared PBKDF2 derivation — single source of truth for iteration count and hash alg.
+  private async deriveServerHash(clientHash: string, salt: Uint8Array): Promise<string> {
     const keyMaterial = await crypto.subtle.importKey(
       'raw',
       new TextEncoder().encode(clientHash),
@@ -145,7 +204,6 @@ export class AuthService {
       false,
       ['deriveBits']
     );
-    const salt = new TextEncoder().encode(email.toLowerCase().trim());
     const bits = await crypto.subtle.deriveBits(
       { name: 'PBKDF2', hash: 'SHA-256', salt, iterations: SERVER_HASH_ITERATIONS },
       keyMaterial,
@@ -154,16 +212,20 @@ export class AuthService {
     const bytes = new Uint8Array(bits);
     let binary = '';
     for (const b of bytes) binary += String.fromCharCode(b);
-    return SERVER_HASH_PREFIX + btoa(binary);
+    return btoa(binary);
   }
 
-  // Verify password: new rows use server-side hashing; legacy rows store the raw client hash.
-  async verifyPassword(inputHash: string, storedHash: string, email: string): Promise<boolean> {
-    if (!storedHash.startsWith(SERVER_HASH_PREFIX)) {
-      return this.constantTimeEquals(inputHash, storedHash);
-    }
-    const serverHash = await this.hashPasswordServer(inputHash, email);
-    return this.constantTimeEquals(serverHash, storedHash);
+  private bytesToBase64(bytes: Uint8Array): string {
+    let binary = '';
+    for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+    return btoa(binary);
+  }
+
+  private base64ToBytes(b64: string): Uint8Array {
+    const binary = atob(b64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
   }
 
   private constantTimeEquals(a: string, b: string): boolean {


### PR DESCRIPTION
改动内容:
- hashPasswordServer: 生成随机 16 字节 salt，输出自描述格式 $<salt_b64>$<hash_b64>
- verifyPassword: 自动识别新旧格式，旧格式 $<hash> 回退 email-salt 验证
- 新增 deriveServerHash/bytesToBase64/base64ToBytes 辅助方法
- atob 异常 try/catch 包裹，畸形输入优雅降级不抛 500
- 显式校验 salt base64 长度(24)和字节数(16)
- email 参数标记 _email 保留签名兼容，新路径不使用

安全修复:
- 消除跨实例碰撞: 同一邮箱在不同部署中哈希不再相同
- 消除 rainbow table: 每个用户拥有独立随机 salt
- 旧用户下次改密时自动升级为新格式，无需迁移

## Summary

<!-- What changed and why? -->

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Compatibility update
- [ ] Documentation
- [ ] Refactor

## Cross-File Checklist

- [ ] I read `CONTRIBUTING.md`.
- [ ] Schema changes, if any, updated both runtime schema and `migrations/0001_init.sql`.
- [ ] Persistent data changes, if any, updated backup export/import or documented why backup is not needed.
- [ ] User-facing text changes, if any, updated all locale files.
- [ ] Bitwarden client compatibility was considered for sync/API shape changes.
- [ ] No secrets, tokens, private deployment values, or real vault data are included.

## Checks

- [ ] `npx tsc -p tsconfig.json --noEmit`
- [ ] `npx tsc -p webapp/tsconfig.json --noEmit`
- [ ] `npm run i18n:validate`
- [ ] `npm run build`

## Notes

<!-- Anything reviewers should pay special attention to? -->
