### PR TITLE
fix(webapp): resolve three errors in the webapp typecheck

### DIFF
--- a/webapp/src/lib/api/backup.ts
+++ b/webapp/src/lib/api/backup.ts
@@ -197,7 +197,7 @@ export async function downloadAdminBackupAttachmentBlob(
   authedFetch: AuthedFetch,
   blobName: string,
   masterPasswordHash: string
-): Promise<Uint8Array> {
+): Promise<Uint8Array<ArrayBuffer>> {
   const resp = await authedFetch('/api/admin/backup/blob', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/webapp/src/lib/backup-center.ts
+++ b/webapp/src/lib/backup-center.ts
@@ -186,7 +186,7 @@ export function invalidateRemoteBrowserCacheForDestination(
   cache: Record<string, RemoteBackupBrowserResponse>,
   pathByDestination: Record<string, string>,
   pageByKey: Record<string, number>
-): PersistedRemoteBrowserState {
+): Omit<PersistedRemoteBrowserState, 'refreshedAt'> {
   return {
     cache: Object.fromEntries(Object.entries(cache).filter(([key]) => !key.startsWith(`${destinationId}:`))),
     pathByDestination: Object.fromEntries(Object.entries(pathByDestination).filter(([key]) => key !== destinationId)),

--- a/webapp/src/lib/password-security-cache.ts
+++ b/webapp/src/lib/password-security-cache.ts
@@ -23,12 +23,16 @@ function createState(fingerprint: string): InternalPasswordSecurityState {
   return { fingerprint, report: null, scannedAt: null, scanning: false, progress: { checked: 0, total: 0 }, scanError: false, controller: null };
 }
 
-export function getPasswordSecurityState(fingerprint: string): PasswordSecurityState {
+function ensurePasswordSecurityState(fingerprint: string): InternalPasswordSecurityState {
   if (state?.fingerprint !== fingerprint) {
     state?.controller?.abort();
     state = createState(fingerprint);
   }
   return state;
+}
+
+export function getPasswordSecurityState(fingerprint: string): PasswordSecurityState {
+  return ensurePasswordSecurityState(fingerprint);
 }
 
 export function readPasswordSecurityState(fingerprint: string): PasswordSecurityState | null {
@@ -41,7 +45,7 @@ export function subscribePasswordSecurityState(listener: () => void): () => void
 }
 
 export function startPasswordSecurityScan(fingerprint: string, ciphers: Cipher[]): void {
-  const current = getPasswordSecurityState(fingerprint);
+  const current = ensurePasswordSecurityState(fingerprint);
   current.controller?.abort();
   const controller = new AbortController();
   const total = ciphers.filter((cipher) => Number(cipher.type) === 1 && !cipher.deletedDate && !(cipher as { deletedAt?: string | null }).deletedAt && !!cipher.login?.decPassword).length;


### PR DESCRIPTION
## Summary

`npx tsc -p webapp/tsconfig.json --noEmit` — one of the checks recommended in `CONTRIBUTING.md` — currently fails on `main` with three errors. This fixes all three.

All three are declaration defects with correct runtime behavior. Two are pure type annotations; the third adds an internal accessor. No observable behavior changes.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Compatibility update
- [ ] Documentation
- [ ] Refactor

## Changes

**`webapp/src/lib/api/backup.ts`** — `downloadAdminBackupAttachmentBlob` declared a bare `Uint8Array` return. Since TypeScript made typed arrays generic, that widens to `Uint8Array<ArrayBufferLike>` and no longer satisfies fflate's `Uint8Array<ArrayBuffer>` at the `zipped[...] = bytes` assignment. The body already returns `new Uint8Array(await resp.arrayBuffer())`, which is concretely `ArrayBuffer`-backed — this only annotates what the function already produces.

**`webapp/src/lib/backup-center.ts`** — `invalidateRemoteBrowserCacheForDestination` declared a full `PersistedRemoteBrowserState` but constructs four of its five fields, omitting `refreshedAt`. The sole caller (`BackupCenterPage.tsx:555`) reads `.cache` only and filters `refreshedAt` through its own setter, so the return type is narrowed to match what the function actually returns rather than adding a field nobody consumes.

**`webapp/src/lib/password-security-cache.ts`** — `getPasswordSecurityState` declared the exported `PasswordSecurityState`, but `startPasswordSecurityScan` needs `controller`, which lives on `InternalPasswordSecurityState`. Added an internal `ensurePasswordSecurityState` accessor so `controller` stays off the public type, which appears to be the intent behind having the `Internal` variant. `getPasswordSecurityState` keeps its existing signature and return value.

## Cross-File Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] Schema changes, if any, updated both runtime schema and `migrations/0001_init.sql`. — no schema changes
- [x] Persistent data changes, if any, updated backup export/import or documented why backup is not needed. — no persisted-format change; see note below
- [x] User-facing text changes, if any, updated all locale files. — no user-facing text
- [x] Bitwarden client compatibility was considered for sync/API shape changes. — no sync or API shape change
- [x] No secrets, tokens, private deployment values, or real vault data are included.

## Checks

- [x] `npx tsc -p tsconfig.json --noEmit`
- [x] `npx tsc -p webapp/tsconfig.json --noEmit`
- [x] `npm run i18n:validate`
- [x] `npm run build`

Additionally verified the webapp and backend typechecks against **TypeScript 5.9.3, 6.0.3 (current), and 7.0.2** — all exit 0 after this change, and all three reported the identical three errors before it. The failures are not specific to any one compiler version.

## Notes

`webapp/src/lib/api/backup.ts` is named in the **Backup And Restore** section of `CONTRIBUTING.md`, so flagging explicitly: this PR changes no backup payload shape, no archive/import whitelist entry, and no persisted format. The change is a return-type annotation on a download helper and emits identical JavaScript.

The only change that alters emitted JS is the `ensurePasswordSecurityState` extraction, which is a rename plus a delegating wrapper — worth the closest look of the three.

Happy to split this into three commits or separate PRs if you'd prefer to take them independently.