### PR TITLE
fix(cipher): clear notes omitted from full updates

### DIFF
--- a/src/handlers/cipher-full-update.ts
+++ b/src/handlers/cipher-full-update.ts
@@ -1,0 +1,32 @@
+interface AliasedValue<T> {
+  present: boolean;
+  value: T | null | undefined;
+}
+
+function readOwnAliasedValue<T>(source: unknown, aliases: readonly string[]): AliasedValue<T> {
+  if (!source || typeof source !== 'object') {
+    return { present: false, value: undefined };
+  }
+
+  const record = source as Record<string, unknown>;
+  for (const alias of aliases) {
+    if (Object.prototype.hasOwnProperty.call(record, alias)) {
+      return { present: true, value: record[alias] as T | null | undefined };
+    }
+  }
+
+  return { present: false, value: undefined };
+}
+
+/**
+ * Full cipher updates use replacement semantics for nullable fields.
+ * Bitwarden clients may omit a property after its value is cleared, so an
+ * absent property must become null instead of falling back to stored data.
+ */
+export function readNullableFullUpdateField<T>(
+  source: unknown,
+  aliases: readonly string[]
+): T | null {
+  const incoming = readOwnAliasedValue<T>(source, aliases);
+  return incoming.present ? incoming.value ?? null : null;
+}

--- a/src/handlers/ciphers.ts
+++ b/src/handlers/ciphers.ts
@@ -27,6 +27,7 @@ import { deleteAllAttachmentsForCipher, deleteAllAttachmentsForCiphers } from '.
 import { parsePagination, encodeContinuationToken } from '../utils/pagination';
 import { readActingDeviceIdentifier } from '../utils/device';
 import { auditRequestMetadata, writeAuditEvent } from '../services/audit-events';
+import { readNullableFullUpdateField } from './cipher-full-update';
 
 // CONTRACT:
 // Cipher JSON is the highest-risk Bitwarden compatibility surface. Preserve
@@ -1100,16 +1101,10 @@ export async function handleUpdateCipher(request: Request, env: Env, userId: str
     cipher.passwordHistory = incomingPasswordHistory.value ?? null;
   }
 
-  // Custom fields deletion compatibility:
-  // - Accept both camelCase "fields" and PascalCase "Fields".
-  // - For full update (PUT/POST on this endpoint), missing fields means cleared fields.
-  //   This prevents stale custom fields from being resurrected by merge fallback.
-  const incomingFields = getAliasedProp(cipherData, ['fields', 'Fields']);
-  if (incomingFields.present) {
-    cipher.fields = incomingFields.value ?? null;
-  } else if (request.method === 'PUT' || request.method === 'POST') {
-    cipher.fields = null;
-  }
+  // Nullable fields use replacement semantics on this full-update endpoint.
+  // Some clients omit cleared values, so merge fallback must not resurrect them.
+  cipher.notes = readNullableFullUpdateField<string>(cipherData, ['notes', 'Notes']);
+  cipher.fields = readNullableFullUpdateField<Cipher['fields']>(cipherData, ['fields', 'Fields']);
   normalizeCipherForStorage(cipher);
   const compatibilityError = validateCipherEncryptedFieldsForCompatibility(cipher);
   if (compatibilityError) return errorResponse(compatibilityError, 400);


### PR DESCRIPTION
## Summary

- treat an omitted `notes` property as cleared on the full cipher update endpoint
- accept both camelCase and PascalCase aliases while preserving the existing replacement semantics for custom fields
- keep the oversized cipher handler thin by delegating the nullable full-update rule to a focused helper

## Root cause

`handleUpdateCipher` merges the stored cipher with the incoming payload to preserve unknown client fields. When a Bitwarden client clears notes and serializes that state by omitting `notes`, the merge retained the previously stored encrypted value. The stale note was then written back to storage and returned on the next sync.

This change applies replacement semantics to nullable fields on the full PUT/POST update endpoint, matching the official server behavior: a missing or explicit null note becomes `null` instead of falling back to stored data.

## Verification

- `npx tsc -p tsconfig.json --noEmit`
- `npm run build`
- end-to-end verification on a disposable Ubuntu 24.04 host with Wrangler local D1:
  - registered and authenticated a test account
  - created a cipher with encrypted notes (`200`)
  - sent a full update with `notes` omitted (`200`)
  - confirmed the item endpoint returns `notes: null`
  - confirmed `/api/sync` returns `notes: null`

Fixes #362