### PR TITLE
Revoke trusted-device tokens when resetting 2FA via recovery code

### DIFF
--- a/src/handlers/accounts.ts
+++ b/src/handlers/accounts.ts
@@ -1473,6 +1473,7 @@ export async function handleRecoverTwoFactor(request: Request, env: Env): Promis
   user.updatedAt = new Date().toISOString();
   await storage.saveUser(user);
   await storage.deleteRefreshTokensByUserId(user.id);
+  await storage.deleteTrustedTwoFactorTokensByUserId(user.id);
   AuthService.invalidateUserCache(user.id);
   await rateLimit.clearLoginAttempts(recoverLimitKey);
   await safeWriteAuditEvent(env, {

--- a/src/handlers/identity.ts
+++ b/src/handlers/identity.ts
@@ -558,6 +558,7 @@ export async function handleToken(request: Request, env: Env): Promise<Response>
         user.updatedAt = new Date().toISOString();
         await storage.saveUser(user);
         await storage.deleteRefreshTokensByUserId(user.id);
+        await storage.deleteTrustedTwoFactorTokensByUserId(user.id);
         AuthService.invalidateUserCache(user.id);
         rememberRequested = false;
       } else {


### PR DESCRIPTION
Fixes #370.

## What changed and why

Both 2FA reset paths — recovery-code login (`src/handlers/identity.ts`) and the `account.totp.recover` endpoint (`src/handlers/accounts.ts`) — wipe the TOTP/YubiKey/passkey enrollment, rotate the security stamp and recovery code, and delete refresh tokens, but they leave rows in `trusted_two_factor_device_tokens` untouched.

Since `passedByRememberToken` only checks the trusted user id (no security-stamp validation), a remember-me token issued before the reset keeps satisfying the 2FA step unilaterally until its original 30-day expiry. Anyone who captured that token (plus the device identifier) therefore retains a 2FA bypass across the reset — exactly the scenario the reset is meant to cut off.

The fix adds one call in each path:

```ts
await storage.deleteTrustedTwoFactorTokensByUserId(user.id);
```

right after the refresh-token deletion, matching what the manual device-management endpoints in `src/handlers/devices.ts` already do.

## User-facing behavior changed

- After resetting 2FA via recovery code, previously trusted devices lose their remember-me status and go through full 2FA again on next login. New remember tokens can be issued normally on the next successful login.

## Related areas checked

- `src/handlers/devices.ts` — same call already exists there for manual device removal, so no double-delete concerns (the delete is idempotent).
- `src/handlers/identity.ts` remember-token issuance — unaffected: the reset paths already force `rememberRequested = false` (login path) / never issue tokens (recover endpoint), and new tokens are only minted on fresh logins.
- Storage layer (`deleteTrustedTwoFactorTokensByUserId`) — no changes needed; the function and the D1 device-repo implementation are already in place.

## Commands run before submitting

- `npm ci`
- `npx tsc --noEmit` — clean
- `npm run test:notifications-security` — all pass
- `npm run test:config-compatibility` — all pass